### PR TITLE
bug: following infrahub-sdk 3.0, default_branch is in the Config

### DIFF
--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -44,8 +44,7 @@ if HAS_INFRAHUBCLIENT:
             """
             self.client = InfrahubClientSync(
                 address=api_endpoint,
-                default_branch=branch,
-                config=Config(api_token=token, timeout=timeout),
+                config=Config(api_token=token, timeout=timeout, default_branch=branch),
             )
             self.branch_manager = InfrahubBranchManagerSync(self.client)
 


### PR DESCRIPTION
Fix issue following infrahub-sdk update to 0.3.0.

default_branch is not a parameter directly but is present in Config.