### PR TITLE
Fix lookup display error

### DIFF
--- a/plugins/action/artifact_fetch.py
+++ b/plugins/action/artifact_fetch.py
@@ -88,6 +88,13 @@ class ActionModule(ActionBase):
             Display().v("Fetch Artifacts")
             result = client.fetch_single_artifact(filters=filters)
 
+            # Better error handling
+            if not result:
+                return {
+                    "failed": True,
+                    "msg": f"Unable to find '{artifact_name}' for '{target_id}'.",
+                }
+
         except Exception as exp:
             raise_from(AnsibleError(str(exp)), exp)
 

--- a/plugins/action/query_graphql.py
+++ b/plugins/action/query_graphql.py
@@ -90,8 +90,9 @@ class ActionModule(ActionBase):
                 branch=branch,
                 timeout=timeout,
                 validate_certs=validate_certs,
+                display=Display(),
             )
-            processor = InfrahubQueryProcessor(client=client)
+            processor = InfrahubQueryProcessor(client=client, display=Display())
             Display().v("Processing Query")
             response = processor.fetch_and_process(query=graphql_query, variables=graph_variables)
             results["data"] = response

--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -168,7 +168,7 @@ class LookupModule(LookupBase):
                 branch=branch,
                 timeout=timeout,
                 validate_certs=validate_certs,
-                display=self.display,
+                display=Display(),
             )
             processor = InfrahubQueryProcessor(client=client, display=Display())
             Display().v("Processing Query")

--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -98,6 +98,7 @@ from typing import Any
 from ansible.errors import AnsibleError, AnsibleLookupError
 from ansible.module_utils.six import raise_from
 from ansible.plugins.lookup import LookupBase
+from ansible.utils.display import Display
 from ansible_collections.opsmill.infrahub.plugins.module_utils.infrahub_utils import (
     HAS_INFRAHUBCLIENT,
     InfrahubclientWrapper,
@@ -160,7 +161,7 @@ class LookupModule(LookupBase):
 
         results = {}
         try:
-            self.display().v("Initializing Infrahub Client")
+            Display().v("Initializing Infrahub Client")
             client = InfrahubclientWrapper(
                 api_endpoint=api_endpoint,
                 token=token,
@@ -169,8 +170,8 @@ class LookupModule(LookupBase):
                 validate_certs=validate_certs,
                 display=self.display,
             )
-            processor = InfrahubQueryProcessor(client=client, display=self.display)
-            self.display().v("Processing Query")
+            processor = InfrahubQueryProcessor(client=client, display=Display())
+            Display().v("Processing Query")
             results = processor.fetch_and_process(query=graphql_query, variables=graph_variables)
 
         except Exception as exc:


### PR DESCRIPTION
In 1.3.0 an error was introduce. self.display is not present in the lookup module, so we have to use `Display` directly.