### PR TITLE
Fixes Relationship cardinality  update via node role

### DIFF
--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -22,7 +22,6 @@ try:
         InfrahubNodeSync,
         RelatedNodeSync,
         RelationshipManagerSync,
-        generate_relationship_property,
     )
     from infrahub_sdk.schema import (
         GenericSchemaAPI,
@@ -1111,7 +1110,6 @@ if HAS_INFRAHUBCLIENT:
                                 schema=rel_schema,
                                 data=rel_data,
                             )
-                            # generate_relationship_property(name=attr_name, node=tmp_obj),
                         )
                     elif rel_schema.cardinality == RelationshipCardinality.MANY:
                         setattr(

--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -1109,7 +1109,7 @@ if HAS_INFRAHUBCLIENT:
                                 branch=self.infrahub_node._branch,
                                 schema=rel_schema,
                                 data=rel_data,
-                            )
+                            ),
                         )
                     elif rel_schema.cardinality == RelationshipCardinality.MANY:
                         setattr(

--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -1092,19 +1092,26 @@ if HAS_INFRAHUBCLIENT:
             # https://github.com/opsmill/infrahub-sdk-python/issues/272
             for attr_name in data:
                 if attr_name in tmp_obj._schema.attribute_names:
-                    attr_schema = next(attr for attr in tmp_obj._schema.attributes if attr.name == attr_name)
+                    attr_schema = next(attr for attr in self.infrahub_node._schema.attributes if attr.name == attr_name)
                     attr_data = data.get(attr_name)
                     new_attr = Attribute(name=attr_name, schema=attr_schema, data=attr_data)
                     setattr(tmp_obj, attr_name, new_attr)
                 elif attr_name in tmp_obj._schema.relationship_names:
-                    rel_schema = next(rel for rel in self._schema.relationships if rel.name == attr_name)
+                    rel_schema = next(rel for rel in self.infrahub_node._schema.relationships if rel.name == attr_name)
                     rel_data = data.get(attr_name)
                     if rel_schema.cardinality == RelationshipCardinality.ONE:
                         setattr(tmp_obj, f"_{attr_name}", None)
                         setattr(
                             tmp_obj,
                             attr_name,
-                            generate_relationship_property(name=attr_name, node=tmp_obj),
+                            RelatedNodeSync(
+                                name=attr_name,
+                                client=self.infrahub_node._client,
+                                branch=self.infrahub_node._branch,
+                                schema=rel_schema,
+                                data=rel_data,
+                            )
+                            # generate_relationship_property(name=attr_name, node=tmp_obj),
                         )
                     elif rel_schema.cardinality == RelationshipCardinality.MANY:
                         setattr(
@@ -1112,9 +1119,9 @@ if HAS_INFRAHUBCLIENT:
                             attr_name,
                             RelationshipManagerSync(
                                 name=attr_name,
-                                client=tmp_obj._client,
+                                client=self.infrahub_node._client,
                                 node=tmp_obj,
-                                branch=tmp_obj._branch,
+                                branch=self.infrahub_node._branch,
                                 schema=rel_schema,
                                 data=rel_data,
                             ),


### PR DESCRIPTION
When updating the relationship of cardinality one, of a node using the node role, the hash was not properly working. Using the relationship `many` as an example, I replaced `generate_relationship_property()` with `RelatedNodeSync()`