### PR TITLE
fix InfraHub to Infrahub in template and resultant Readme.

### DIFF
--- a/docs/_templates/readme.mdx.j2
+++ b/docs/_templates/readme.mdx.j2
@@ -6,13 +6,13 @@ Collection version {{ collection_version }}
 
 ## Collection overview
 
-The OpsMill InfraHub Ansible Collection provides is intend to help interact with Infrahub through Ansible.
+The OpsMill Infrahub Ansible Collection provides is intend to help interact with Infrahub through Ansible.
 
 This Ansible collection consists of a set of modules and plugins designed to work seamlessly with your existing infrastructure, enabling you to define and enforce the desired state of your infrastructure with ease.
 
 ## Guides
 
-To begin using the OpsMill InfraHub Ansible Collection, please follow our step-by-step guides:
+To begin using the OpsMill Infrahub Ansible Collection, please follow our step-by-step guides:
 
 * **[Installation Guide](./guides/installation.mdx)**: Learn how to install the collection, including Python module and Ansible setup, as well as alternative installation options.
 * **[Dynamic Inventory Guide](./guides/dynamic-inventory.mdx)**: Discover how to leverage the collection's dynamic inventory features to streamline your infrastructure management.

--- a/docs/docs/readme.mdx
+++ b/docs/docs/readme.mdx
@@ -6,13 +6,13 @@ Collection version 1.4.4
 
 ## Collection overview
 
-The OpsMill InfraHub Ansible Collection provides is intend to help interact with Infrahub through Ansible.
+The OpsMill Infrahub Ansible Collection provides is intend to help interact with Infrahub through Ansible.
 
 This Ansible collection consists of a set of modules and plugins designed to work seamlessly with your existing infrastructure, enabling you to define and enforce the desired state of your infrastructure with ease.
 
 ## Guides
 
-To begin using the OpsMill InfraHub Ansible Collection, please follow our step-by-step guides:
+To begin using the OpsMill Infrahub Ansible Collection, please follow our step-by-step guides:
 
 * **[Installation Guide](./guides/installation.mdx)**: Learn how to install the collection, including Python module and Ansible setup, as well as alternative installation options.
 * **[Dynamic Inventory Guide](./guides/dynamic-inventory.mdx)**: Discover how to leverage the collection's dynamic inventory features to streamline your infrastructure management.


### PR DESCRIPTION
Fixing auto-generated references to `InfraHub` vs `Infrahub`.