### PR TITLE
Update argument_specs.yml

### DIFF
--- a/roles/install/meta/argument_specs.yml
+++ b/roles/install/meta/argument_specs.yml
@@ -22,7 +22,7 @@ argument_specs:
           - Install directory for the Infrahub files (docker-compose and configuration file).
         type: str
         default: /opt/infrahub
-      infrahub_config:
+      install_infrahub_config:
         description:
           - Environment variables to pass as configuration for Infrahub.
         type: dict

--- a/roles/install/templates/config.env.j2
+++ b/roles/install/templates/config.env.j2
@@ -1,5 +1,5 @@
 # Infrahub configuration
-{% for k, v in infrahub_config.items() %}
+{% for k, v in install_infrahub_config.items() %}
 {{ k }}={{ v }}
 {% endfor %}
 {% if install_infrahub_version is defined %}


### PR DESCRIPTION
The argument `infrahub_config` on the install role was not properly updated in all the different files.
Causing a crash if it was not defined when calling the role, which should not be the case. 