### PR TITLE
Fix compatibility with infrahub-sdk v1.13.0+

### DIFF
--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -17,8 +17,13 @@ try:
     from infrahub_sdk import Config, InfrahubClientSync
     from infrahub_sdk.exceptions import BranchNotFoundError
     from infrahub_sdk.graphql import Query
+    
+    try:
+        from infrahub_sdk.node.attribute import Attribute
+    except ImportError:
+        from infrahub_sdk.node import Attribute
+    
     from infrahub_sdk.node import (
-        Attribute,
         InfrahubNodeSync,
         RelatedNodeSync,
         RelationshipManagerSync,


### PR DESCRIPTION
- Handle breaking change where Attribute moved from infrahub_sdk.node to infrahub_sdk.node.attribute
- Maintains backward compatibility with SDK < 1.13.0

## Related Issue
<!--
Add the related issue in the form of #issue-number (Example #100)
-->
No existing issue - discovered during testing with infrahub-sdk v1.13.0

## New Behavior
<!--
Please describe in a few words the intentions of your PR.
-->
The collection now supports both infrahub-sdk v1.13.0+ and earlier versions by using a try/except import pattern for the `Attribute` class, which was moved to a new module path in SDK v1.13.0.

## Contrast to Current Behavior
<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->
Previously, the collection would fail with `ImportError: cannot import name 'Attribute' from 'infrahub_sdk.node'` when using infrahub-sdk v1.13.0+. Now it gracefully handles both the old and new import paths.

## Discussion: Benefits and Drawbacks
<!--
Please make your case here:
- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.
(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->
**Benefits:**
- Fixes compatibility with current infrahub-sdk versions (v1.13.0+)
- Maintains backward compatibility with older SDK versions
- Users can upgrade SDK without breaking their Ansible workflows

**Drawbacks:**
- None

**Backwards Compatible:** 
Yes, backwards compatible with SDK versions < 1.13.0

## Changes to the Documentation
<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->
No documentation changes needed - this is an internal compatibility fix that doesn't affect the user-facing API.

## Proposed Release Note Entry
<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->
**Fixed:** Compatibility with infrahub-sdk v1.13.0+ by handling the breaking change where `Attribute` class was moved to `infrahub_sdk.node.attribute`. The collection now supports both new and legacy SDK versions.

## Double Check
<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->
* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `develop` branch.