### PR TITLE
Lower mccabe complexity rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ max-line-length = 150
 
 [tool.ruff.lint.mccabe]
 # Target max-complexity=10
-max-complexity = 33
+max-complexity = 19
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION

## Contrast to Current Behavior

Lower mccabe complexity to 19 as that's the current max. This prevents us from introducing further complexity.