### PR TITLE
Provide a deep_update method to solve an issue with nested information

### DIFF
--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -469,6 +469,20 @@ if HAS_INFRAHUBCLIENT:
                 elif level == "INFO":
                     self.display.v(error_msg)
 
+        @staticmethod
+        def deep_update(source: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:
+            """
+            Update a nested dictionary or similar mapping.
+            Modify ``source`` in place.
+            """
+            for key, value in overrides.items():
+                if isinstance(value, dict) and value:
+                    returned = InfrahubBaseProcessor.deep_update(source.get(key, {}), value)
+                    source[key] = returned
+                else:
+                    source[key] = value
+            return source
+
         def resolve_node_mapping(
             self, node: InfrahubNodeSync, attrs: list[str], schemas: dict[str, Any], include_id: bool = True
         ) -> dict[str, Any] | None:
@@ -539,7 +553,7 @@ if HAS_INFRAHUBCLIENT:
                                         node=related_node, attrs=peer_attributes, schemas=schemas, include_id=True
                                     )
                                     if isinstance(attribute_dict[parts[0]], dict):
-                                        attribute_dict[parts[0]].update(nested_result)
+                                        self.deep_update(attribute_dict[parts[0]], nested_result)
                                     else:
                                         attribute_dict[parts[0]] = nested_result
 

--- a/tests/unit/test_deep_update.py
+++ b/tests/unit/test_deep_update.py
@@ -10,7 +10,3 @@ class TestDeepUpdate(unittest.TestCase):
         expected = {"a": {"b": {"c": {"d": {"e": {"f": 2, "g": 3}, "h": 4}}, "i": 5}}, "j": 6, "z": 1}
         result = InfrahubBaseProcessor.deep_update(source, overrides)
         self.assertEqual(result, expected)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unit/test_deep_update.py
+++ b/tests/unit/test_deep_update.py
@@ -4,7 +4,7 @@ from ansible_collections.opsmill.infrahub.plugins.module_utils.infrahub_utils im
 
 
 class TestDeepUpdate(unittest.TestCase):
-    def test_deep_update_nested(self):
+    def test_deep_update_nested(self) -> None:
         source = {"a": {"b": {"c": {"d": {"e": {"f": 1}}}}}, "z": 1}
         overrides = {"a": {"b": {"c": {"d": {"e": {"f": 2, "g": 3}, "h": 4}}, "i": 5}}, "j": 6}
         expected = {"a": {"b": {"c": {"d": {"e": {"f": 2, "g": 3}, "h": 4}}, "i": 5}}, "j": 6, "z": 1}

--- a/tests/unit/test_deep_update.py
+++ b/tests/unit/test_deep_update.py
@@ -1,0 +1,16 @@
+import unittest
+
+from ansible_collections.opsmill.infrahub.plugins.module_utils.infrahub_utils import InfrahubBaseProcessor
+
+
+class TestDeepUpdate(unittest.TestCase):
+    def test_deep_update_nested(self):
+        source = {"a": {"b": {"c": {"d": {"e": {"f": 1}}}}}, "z": 1}
+        overrides = {"a": {"b": {"c": {"d": {"e": {"f": 2, "g": 3}, "h": 4}}, "i": 5}}, "j": 6}
+        expected = {"a": {"b": {"c": {"d": {"e": {"f": 2, "g": 3}, "h": 4}}, "i": 5}}, "j": 6, "z": 1}
+        result = InfrahubBaseProcessor.deep_update(source, overrides)
+        self.assertEqual(result, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Related Issue
Fixes #247 

<!--
Add the related issue in the form of #issue-number (Example #100)
-->

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

We now provide nested data into the original variable without overwriting or missing the data.

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

It seems that after a certain level when using multiple `includes` that follow the same variable path, but deeper, aren't added.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

This allows a user to set/fetch nested data within their host vars.

## Changes to the Documentation

<!--
If the docs must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

N/A

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

Properly set multiple includes that follow the same related node path, but deeper than a single level, in the host var path.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [X] I have explained my PR according to the information in the comments or in a linked issue.
* [X] My PR targets the `develop` branch.