### PR TITLE
Temporary hotfix

### DIFF
--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -284,7 +284,7 @@ if HAS_INFRAHUBCLIENT:
                     exclude=exclude,
                     branch=branch,
                     prefetch_relationships=prefetch_relationships,
-                    parallel=True,
+                    parallel=False,
                     property=False,
                     order=order,
                     **filters,


### PR DESCRIPTION
Rolling back parallel when filters are given.

Right now there is an issue on the SDK/Server causing wrong results when both are given.