### PR TITLE
Fix _resolve_many_relationship not fetching peers for nested nodes

### DIFF
--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -593,6 +593,9 @@ if HAS_INFRAHUBCLIENT:
             store = self.client.client.store
             peers: list[Any] = []
 
+            if not node_attr.peers:
+                node_attr.fetch()
+
             for peer in node_attr.peers:
                 related_node = store.get(key=peer.id, raise_when_missing=False)
                 if not related_node:


### PR DESCRIPTION
## Related Issue

  <!--No related issue-->

  ## New Behavior

  `_resolve_many_relationship` now calls `fetch()` on the
  `RelationshipManagerSync` before iterating peers when the peers list
  is empty.

  ## Contrast to Current Behavior

  Previously, many-cardinality relationships on nodes fetched as related
  nodes (level 2+) always returned empty lists. For example, given a
  schema like `Device → Site → Tags`, the `tags` relationship on `Site`
  would never be populated because only the root `Device` node is fetched
  with `prefetch_relationships=True`. The nested `Site` node's
  `RelationshipManagerSync` has an empty peers list until `fetch()` is
  called explicitly.

  ## Discussion: Benefits and Drawbacks

  **Benefits:**
  - Inventory variables derived from nested many-cardinality relationships
    now resolve correctly without requiring schema or query changes.
  - Consistent with `_resolve_one_relationship`, which already calls
    `fetch()` when the related node is not in the store.

  **Drawbacks:**
  - Adds one extra API call per unpopulated many-cardinality relationship
    on nested nodes. This is unavoidable given the SDK's lazy-loading
    behaviour for related nodes.

  **Backwards-compatible:** Yes. The change only triggers when peers is
  empty; populated peers lists are unaffected.

  ## Changes to the Documentation

  None required.

  ## Proposed Release Note Entry

  Fixed `_resolve_many_relationship` to call `fetch()` on
  `RelationshipManagerSync` before iterating peers, resolving an issue
  where nested many-cardinality relationships always returned empty lists
  in inventory output.

  ## Double Check

  * [x] I have explained my PR according to the information in the comments or in a linked issue.
  * [x] My PR targets the `develop` branch.