### PR TITLE
fix(docs): unbreak MDX build for object_file_fetch and harden CI

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -28,5 +28,6 @@ markdown_all: &markdown_all
   - "**/*.{md,mdx}"
 
 documentation_all:
+  - *ansible_plugins
   - *doc_files
   - *markdown_all

--- a/.github/workflows/workflow-changelog-and-docs.yml
+++ b/.github/workflows/workflow-changelog-and-docs.yml
@@ -31,6 +31,20 @@ jobs:
       - name: "Generate Docs"
         run: "uv run invoke generate-doc"
 
+      - name: "Setup Node.js"
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: docs/package-lock.json
+
+      - name: "Install Node dependencies"
+        run: npm install
+        working-directory: ./docs
+
+      - name: "Build documentation"
+        run: "uv run invoke docusaurus"
+
       - name: commit docs
         uses: github-actions-x/commit@v2.9
         with:

--- a/docs/_templates/plugin.mdx.j2
+++ b/docs/_templates/plugin.mdx.j2
@@ -5,7 +5,7 @@ description: {{ documentation.get('short_description', '') }}
 
 # {{ plugin_type.title() }} {{ plugin_type.lower() }}
 
-{% for description in documentation.get('description', '') %}{{ description }} {% endfor %}
+{% for description in documentation.get('description', '') %}{{ description | mdx_safe }} {% endfor %}
 
 {% if documentation.get('options') -%}
 ## Parameters
@@ -13,7 +13,7 @@ description: {{ documentation.get('short_description', '') }}
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 {%- for param_name, param in documentation.options.items() %}
-| `{{ param_name }}` | `{{ param.get('type', '') }}` | {{ "Yes" if param.get('required', False) else "No" }} | {{ param.get('default', '') }} | {{ param.get('description', '') if param.get('description') is string else param.get('description', [])|join(' ') }} |
+| `{{ param_name }}` | `{{ param.get('type', '') }}` | {{ "Yes" if param.get('required', False) else "No" }} | {{ param.get('default', '') }} | {{ param.get('description', '') | mdx_safe }} |
 {%- endfor %}
 {%- endif %}
 {% if examples %}
@@ -30,6 +30,6 @@ description: {{ documentation.get('short_description', '') }}
 | Key | Type | Description |
 |-----|------|-------------|
 {%- for key, data in returns.items() %}
-| `{{ key }}` | `{{ data.get('type', '') }}` | {{ data.get('description', '') if data.get('description') is string else data.get('description', [])|join(' ') }} |
+| `{{ key }}` | `{{ data.get('type', '') }}` | {{ data.get('description', '') | mdx_safe }} |
 {%- endfor %}
 {% endif %}

--- a/docs/docs/references/plugins/object_file_fetch_module.mdx
+++ b/docs/docs/references/plugins/object_file_fetch_module.mdx
@@ -19,7 +19,7 @@ Downloads the binary file content stored on a CoreFileObject schema node. Identi
 | `kind` | `str` | Yes |  | Schema kind that inherits from CoreFileObject (e.g. C(NetworkCircuitContract)) |
 | `node_id` | `str` | No |  | UUID of the CoreFileObject node to fetch. One of I(node_id) or I(hfid) is required. |
 | `hfid` | `list` | No |  | Human-friendly ID component values for the CoreFileObject node. One of I(node_id) or I(hfid) is required. |
-| `dest` | `str` | No | None | Local path to save the file content. When a directory path is given (trailing slash or existing directory), the file is saved as C({dest}/{node.file_name}). When a file path is given, the file is saved exactly at that path. When omitted, file content is returned as variables only. |
+| `dest` | `str` | No | None | Local path to save the file content. When a directory path is given (trailing slash or existing directory), the file is saved as `{dest}/{node.file_name}`. When a file path is given, the file is saved exactly at that path. When omitted, file content is returned as variables only. |
 
 ## Examples
 

--- a/plugins/modules/object_file_fetch.py
+++ b/plugins/modules/object_file_fetch.py
@@ -72,7 +72,7 @@ options:
         description:
             - Local path to save the file content.
             - When a directory path is given (trailing slash or existing directory),
-              the file is saved as C({dest}/{node.file_name}).
+              the file is saved as `{dest}/{node.file_name}`.
             - When a file path is given, the file is saved exactly at that path.
             - When omitted, file content is returned as variables only.
         type: str

--- a/tasks/docs.py
+++ b/tasks/docs.py
@@ -1,11 +1,33 @@
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 from typing import Any, NamedTuple
 
 import yaml
 from invoke import Context, task
+
+# Splits text on Markdown inline code spans (single backticks) so MDX-escaping
+# only runs on prose, not on code spans where `{var}` is already safe.
+_CODE_SPAN_RE = re.compile(r"(`[^`]+`)")
+
+
+def mdx_safe(value: object) -> str:
+    """Render a docstring description as MDX-safe text.
+
+    Joins list-style descriptions into one line and escapes JSX-reserved braces
+    that appear outside Markdown code spans, preventing MDX from interpreting
+    placeholders like ``{var}`` as JSX expressions referencing undefined names.
+    """
+    if value is None:
+        return ""
+    text = " ".join(str(item) for item in value) if isinstance(value, list) else str(value)
+    parts = _CODE_SPAN_RE.split(text)
+    return "".join(
+        part if index % 2 == 1 else part.replace("{", r"\{").replace("}", r"\}") for index, part in enumerate(parts)
+    )
+
 
 MAIN_DIRECTORY = "."
 NAMESPACE = "INFRAHUB-ANSIBLE-DOCS"
@@ -228,6 +250,7 @@ def generate_docs(context: Context, debug: bool = False, plugin_type: str | None
         trim_blocks=False,
         lstrip_blocks=True,
     )
+    environment.filters["mdx_safe"] = mdx_safe
 
     plugin_template = environment.from_string((template_dir / "plugin.mdx.j2").read_text())
     readme_template = environment.from_string((template_dir / "readme.mdx.j2").read_text())


### PR DESCRIPTION
## Related Issue

Surfaced by a build failure on opsmill/infrahub-docs `main`: https://github.com/opsmill/infrahub-docs/actions/runs/25342922472

## New Behavior

- The `object_file_fetch` plugin's `dest` description renders as `` `{dest}/{node.file_name}` `` inside a code span — MDX treats it as literal text instead of a JSX expression.
- A new `mdx_safe` Jinja filter escapes stray `{`/`}` in description text outside Markdown code spans, so future plugin docstrings can't reintroduce the same break.
- `documentation_all` in `.github/file-filters.yml` now also matches `plugins/**` so the `documentation-lint` job runs when plugin source changes.
- `workflow-changelog-and-docs.yml` builds the Docusaurus site (`uv run invoke docusaurus`) after `invoke generate-doc` and before the auto-commit, so broken MDX never lands on `stable`.

## Contrast to Current Behavior

Previously, `plugins/modules/object_file_fetch.py` shipped a docstring containing `C({dest}/{node.file_name})`. The Jinja-to-MDX template emits descriptions verbatim, and Docusaurus parsed `{dest}` as a JSX expression, crashing SSG with `ReferenceError: dest is not defined` whenever the docs aggregator (opsmill/infrahub-docs) tried to build.

Two CI gaps allowed the broken docstring to land on `stable`:
1. The `documentation_all` paths-filter excluded `plugins/**`, so the `documentation-lint` job was skipped on PRs that only touched plugin source.
2. `workflow-changelog-and-docs.yml` regenerated MDX from plugin docstrings and auto-committed to `stable` without ever running a Docusaurus build to validate the result.

The aggregator repo was the first place the broken MDX met the compiler.

## Discussion: Benefits and Drawbacks

**Benefits:** Unblocks the aggregator build, eliminates the path filter / build-validation gaps that allowed it to slip through, and the Jinja filter provides defense-in-depth so the same failure mode cannot recur via a different plugin.

**Drawbacks / risks:** The new docs-build step in `workflow-changelog-and-docs.yml` adds ~1–2 minutes of CI time per push to `stable` and pulls Node + npm dependencies into a workflow that previously only used Python. Worth the cost given the alternative is broken docs landing on `stable`.

Backwards-compatible: regenerating all existing plugin docs with the new template + filter produces a byte-identical diff except for the targeted `object_file_fetch_module.mdx` line.

## Changes to the Documentation

`docs/docs/references/plugins/object_file_fetch_module.mdx` is regenerated from the corrected docstring. Verified locally with `cd docs && npm run build` → `[SUCCESS] Generated static files in "build"`.

## Proposed Release Note Entry

Fix MDX build break in `object_file_fetch` documentation; add CI guard so plugin-docstring changes are validated by a Docusaurus build before landing on `stable`.

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [ ] My PR targets the `develop` branch. (Targeting `stable` because the broken docstring is on `stable` and that's the branch the aggregator pulls from. Happy to re-target if preferred.)