### PR TITLE
fix(node): include user keys on fetch to avoid spurious changed status

### DIFF
--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -1298,8 +1298,11 @@ if HAS_INFRAHUBCLIENT:
             if not node_id and not node_hfid:
                 return None
 
+            include = [key for key in data if key not in ("id", "hfid")] or None
             try:
-                node = self.client.fetch_single_node(kind=kind, id=node_id, hfid=node_hfid, raise_when_missing=False)
+                node = self.client.fetch_single_node(
+                    kind=kind, id=node_id, hfid=node_hfid, include=include, raise_when_missing=False
+                )
             except Exception as exc:
                 self._handle_errors(f"An error occurred while retrieving {kind} {data} due to {exc}")
 

--- a/tests/unit/plugins/module_utils/test_node.py
+++ b/tests/unit/plugins/module_utils/test_node.py
@@ -541,6 +541,54 @@ class TestRealChecksumComputation:
 
 
 # ---------------------------------------------------------------------------
+# Regression: _get_object must pass user data keys as include on fetch.
+# Without include, cardinality-MANY relationships stay uninitialized on the
+# fetched node and are missing from the "before" diff snapshot, so idempotent
+# re-runs report changed: true (fixed in 6f1315e, lost in 0142ad6).
+# ---------------------------------------------------------------------------
+
+
+class TestGetObjectIncludesUserKeys:
+    def test_fetch_includes_user_data_keys(self):
+        """_get_object passes user field names as include, excluding id/hfid."""
+        mock_client = make_mock_client(existing_node=make_mock_node())
+        mock_module = make_mock_module()
+
+        node_module = NodeModule(module=mock_module, client=mock_client)
+        data = {
+            "id": "uuid-1234",
+            "name": {"value": "tag1"},
+            "description": {"value": "managed by ansible"},
+            "related_tags": [{"id": "uuid-5678"}],
+        }
+        node_module._get_object(schema=MagicMock(), kind="BuiltinTag", data=data)
+
+        mock_client.fetch_single_node.assert_called_once_with(
+            kind="BuiltinTag",
+            id="uuid-1234",
+            hfid=None,
+            include=["name", "description", "related_tags"],
+            raise_when_missing=False,
+        )
+
+    def test_fetch_identifier_only_defaults_include_to_none(self):
+        """Identifier-only data (e.g. state: absent) keeps default fetch behavior."""
+        mock_client = make_mock_client(existing_node=make_mock_node())
+        mock_module = make_mock_module()
+
+        node_module = NodeModule(module=mock_module, client=mock_client)
+        node_module._get_object(schema=MagicMock(), kind="BuiltinTag", data={"id": "uuid-1234"})
+
+        mock_client.fetch_single_node.assert_called_once_with(
+            kind="BuiltinTag",
+            id="uuid-1234",
+            hfid=None,
+            include=None,
+            raise_when_missing=False,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Schema-based version gating (CoreFileObject inherit_from validation)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The `node` module can report `changed: true` on idempotent re-runs of a task whose `data` includes a relationship. Re-applying the exact same payload should be a no-op but currently flips status to `changed`.

## Root cause

`_get_object` calls `fetch_single_node` without an `include` list, so cardinality-MANY non-attribute/non-parent relationships are not requested in the GraphQL query and stay uninitialized on the returned node. When `_update_object` builds the diff:

- `serialized_before = node._generate_input_data()` — skips uninitialized relationships (SDK: `if not rel.initialized: continue`).
- `setattr(node, rel_name, …)` initializes the relationship.
- `serialized_after = node._generate_input_data()` — now includes the relationship.

`dict_hash(serialized_before) != dict_hash(serialized_after)` even when the underlying value matches → false `changed: true`.

This regressed when the original include-on-fetch fix (commit `6f1315e`) was removed during the diff rework in `0142ad6`.

## Fix

In `_get_object`, derive `include` from the user-provided `data` keys (excluding `id` / `hfid` which are not schema fields) and pass it to `fetch_single_node`. Empty list collapses to `None` so the `state: absent` path and identifier-only lookups keep their default fetch behavior.

```python
include = [key for key in data if key not in ("id", "hfid")] or None
node = self.client.fetch_single_node(
    kind=kind, id=node_id, hfid=node_hfid, include=include, raise_when_missing=False
)
```

## Test plan

- [x] Unit tests pass: `pytest tests/unit/plugins/module_utils/test_node.py` → 23/23
- [x] Integration cycle playbook against `sandbox.infrahub.app`:
  - `Create tag1` → changed
  - `Update tag1` → changed
  - `Existing tag1` → **ok (not changed)** ← the idempotency assertion this PR restores
  - `Delete tag1` → changed
  - `Delete tag1` (already absent) → ok
- [ ] Re-run the cycle playbook a second time to confirm deterministic idempotency on relationship-bearing kinds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false changed status in the `node` module by fetching nodes with the user’s fields included. Adds regression tests to prevent this idempotency issue from returning.

- **Bug Fixes**
  - Derive `include` from user `data` keys (excluding `id` and `hfid`) and pass to `fetch_single_node`.
  - Ensure relationships are initialized in the "before" snapshot to avoid spurious diffs.
  - Fall back to default fetch when only identifiers are provided, preserving `state: absent` and lookup behavior.
  - Add unit tests asserting `include` contains user keys and defaults to `None` for identifier-only data.

<sup>Written for commit 0f977e175a0b93a9793f935a4dd755f086010a2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-ansible/pull/334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

