### PR TITLE
Backport Stable

### DIFF
--- a/docs/docs/readme.mdx
+++ b/docs/docs/readme.mdx
@@ -2,7 +2,7 @@
 title: opsmill.infrahub Ansible collection
 ---
 
-Collection version 1.8.0
+Collection version 1.8.1
 
 ## Collection overview
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ namespace: opsmill
 name: infrahub
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.8.1
+version: 1.8.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub_ansible_modules"
-version = "1.8.1"
+version = "1.8.2"
 description = "Ansible collection to interact with Infrahub's API"
 authors = [{name = "OpsMill", email = "info@opsmill.com"}]
 license = {text = "GPLv3"}

--- a/uv.lock
+++ b/uv.lock
@@ -720,7 +720,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-ansible-modules"
-version = "1.8.1"
+version = "1.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.19.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Backports the 1.8.2 version bump for the Ansible collection to the stable branch. Updates `galaxy.yml`, `pyproject.toml`, and `uv.lock`; refreshes the docs readme version text.

<sup>Written for commit 64949412bc6ed0d639834db707757827c7d1d69f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-ansible/pull/338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

