### PR TITLE
fix(tests): rename bare _ to satisfy ansible-test sanity pylint

### DIFF
--- a/tests/integration/inventory/schema.py
+++ b/tests/integration/inventory/schema.py
@@ -101,7 +101,7 @@ def seed_dataset(client: InfrahubClientSync) -> dict:
     sites: dict[str, object] = {}
     tags: dict[str, object] = {}
 
-    for _, _, _, site_name, region_name, _, host_tags in HOSTS:
+    for _name, _role, _platform, site_name, region_name, _address, host_tags in HOSTS:
         if region_name not in regions:
             node = client.create(kind=REGION, name=region_name)
             node.save()
@@ -116,7 +116,7 @@ def seed_dataset(client: InfrahubClientSync) -> dict:
                 node.save()
                 tags[tag_name] = node
 
-    for name, role, platform, site_name, _, address, host_tags in HOSTS:
+    for name, role, platform, site_name, _region_name, address, host_tags in HOSTS:
         addr = client.create(kind=ADDRESS, address=address)
         addr.save()
         host = client.create(

--- a/tests/integration/inventory/test_inventory_integration.py
+++ b/tests/integration/inventory/test_inventory_integration.py
@@ -77,13 +77,13 @@ class TestInventoryIntegration(TestInfrahubDockerClient):
         return _parse_cli_inventory(result.stdout)
 
     def test_cli_basic_lists_all_hosts(self, infrahub_port, dataset):
-        hosts, _, hostvars = self._run_cli(infrahub_port, "basic.yml")
+        hosts, _groups, hostvars = self._run_cli(infrahub_port, "basic.yml")
         assert hosts == ALL_HOSTS
         assert hostvars["host-a"]["role"] == "edge"
         assert hostvars["host-d"]["platform"] == "nxos"
 
     def test_cli_grouping(self, infrahub_port, dataset):
-        hosts, groups, _ = self._run_cli(infrahub_port, "grouping.yml")
+        hosts, groups, _hostvars = self._run_cli(infrahub_port, "grouping.yml")
         assert hosts == ALL_HOSTS
         assert groups["site_paris"] == {"host-a", "host-b"}
         assert groups["site_denver"] == {"host-c", "host-d"}


### PR DESCRIPTION
## Related Issue

None — this unblocks the `develop` → `stable` release-sync PR, whose `sanity-py3.11-2.19` job was failing.

## New Behavior

`ansible-test sanity` (pylint) passes on the testcontainers integration tests.

## Contrast to Current Behavior

The newly-merged integration tests used the bare `_` throwaway in tuple unpacking, which ansible-test's pylint forbids (`disallowed-name: Disallowed name "_"`) — failing the sanity job in CI:

- `tests/integration/inventory/schema.py:104,119`
- `tests/integration/inventory/test_inventory_integration.py:80,86`

The bare `_` are renamed to descriptive underscore-prefixed names (`_name`, `_role`, `_region_name`, `_groups`, `_hostvars`, …). Underscore-*prefixed* names satisfy ansible-test pylint (only the bare `_` is in its `bad-names`) **and** ruff's `B007` / `RUF059` (the old ansible `dummy` convention would have failed ruff — verified).

## Discussion: Benefits and Drawbacks

- Unblocks the `develop` → `stable` sync PR.
- Test-only change; no runtime/plugin code touched, fully backwards-compatible.
- Verified locally: `invoke tests-sanity` passes (pylint clean, 0 `disallowed-name`), `ruff check .` clean repo-wide, and the full testcontainers integration suite (13 tests) passes.

## Changes to the Documentation

None — no behavioral or API change.

## Proposed Release Note Entry

N/A — test-only sanity-compliance fix (`ci/skip-changelog`).

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `develop` branch.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed bare `_` throwaways in integration tests to underscore-prefixed names (e.g., `_name`, `_role`). This satisfies `ansible-test` `pylint` (disallowed-name "_") and `ruff`, unblocking the develop → stable release sync.

<sup>Written for commit 161e982339849328787d68f2cb6f6bd4cc65e4db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-ansible/pull/352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

