### PR TITLE
chore(agentic): pin spec-kit release (align with canonical structure)

### DIFF
--- a/.specify/init-options.json
+++ b/.specify/init-options.json
@@ -1,0 +1,3 @@
+{
+  "speckit_version": "0.8.11"
+}


### PR DESCRIPTION
<!-- repo-drift-detection:pr -->
## Agentic structure alignment

This PR applies the one fix found by the `auditing-agentic-structure` engine (run via `detecting-repo-drift`). The repo is otherwise **fully aligned** with the canonical agentic layout — the audit reports **0 errors** on both `develop` and `stable`.

### Rule satisfied
- [x] `speckit-installed` — records an exact `speckit_version` pin (`0.8.11`) in the canonical `.specify/init-options.json`, so the installed spec-kit engine is reproducible. Previously **no pin was recorded anywhere** (no `init-options.json`, no install-command pin, no `dev/` note). Re-running the checker against this branch drops the warning count from 1 → 0.

### How the version was determined
`0.8.11` is the `specify-cli` release currently installed on the maintainer's machine (`uv tool list` → `specify-cli v0.8.11`), which is consistent with the spec-kit install date in #296 (Feb 2026; upstream is now on the 0.11.x line). The repo records no version anywhere and the install has local modifications, so the exact release cannot be recovered mechanically.

> ⚠️ **Reviewer check:** if the spec-kit release actually used differs from `0.8.11`, correct the value before merging — a wrong pin is worse than none, since the pin's whole purpose is reproducibility. This single value is the human-judgement part of an otherwise mechanical fix.

### Advisory — not a fix, no issue opened
- `claude-adapter-shape` (info) — `.claude/commands` is a correct-source committed symlink and **passes**. Committed symlinks clone as plain text on Windows / some CI checkouts without `core.symlinks=true`. Optional hardening (gitignore the view + regenerate it as real files) is available if the repo must support those environments — deliberately left as a human call, not drift.

### Ship-gate
Verified by **3 independent adversarial judges** (traceability → resolution → idempotency → scope): unanimous **PASS**. No prior `agentic-drift` PR/issue existed, so this is a first, non-duplicate fix.

---
Generated by the `detecting-repo-drift` skill. Review before merging.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the spec-kit release to 0.8.11 in .specify/init-options.json so installs are reproducible and the agentic layout matches the canonical structure. Clears the `speckit-installed` audit warning; the repo is now fully aligned.

<sup>Written for commit 7842720519bd55e1c76abe3024cbd835ae7e6ea1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-ansible/pull/354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

