### PR TITLE
ci: make the python linters run when their config or version changes

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -9,8 +9,15 @@ ansible_plugins: &ansible_plugins
 ansible_docs: &ansible_docs
   - "docs/**"
 
+# The Python linters are configured by pyproject.toml and pinned by uv.lock, so a
+# change to either can change what `ruff`/`mypy` report without touching a single
+# .py file. Leaving them out meant the job that runs those linters never fired on
+# the change that altered them — which is how a ruff bump landed on develop and
+# left it failing lint for anyone who ran it locally.
 python_all:
   - "**/*.py"
+  - "pyproject.toml"
+  - "uv.lock"
 
 yaml_all:
   - "**/*.{yml,yaml}"

--- a/.github/workflows/workflow-linter.yml
+++ b/.github/workflows/workflow-linter.yml
@@ -108,7 +108,10 @@ jobs:
       run:
         working-directory: ./docs
     if: needs.files-changed.outputs.documentation == 'true'
-    needs: ["files-changed", "python-lint"]
+    # Gated on the documentation filter alone. Depending on python-lint made this
+    # inherit that job's skips: a docs-only change skips python-lint, and a skipped
+    # dependency skips its dependents, so the docs build silently never ran.
+    needs: ["files-changed"]
     runs-on: "ubuntu-22.04"
     timeout-minutes: 5
     steps:
@@ -134,7 +137,12 @@ jobs:
         run: "invoke docusaurus"
 
   validate-documentation-style:
-    needs: ["files-changed", "python-lint"]
+    # Same fix as documentation-lint, plus the filter it never had: this job was
+    # gated only by inheriting python-lint's outcome, so it ran whenever Python
+    # changed and skipped whenever Python did not — neither of which has anything
+    # to do with prose style.
+    if: needs.files-changed.outputs.documentation == 'true'
+    needs: ["files-changed"]
     runs-on: "ubuntu-22.04"
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## Related Issue

_None — found while monitoring CI on #373._

## New Behavior

A change to `pyproject.toml` or `uv.lock` now triggers `linter / python-lint`, and the two documentation jobs no longer skip just because `python-lint` did.

Verified by replaying both filter versions against the exact file sets that slipped through:

| change | `python-lint` before | after |
|---|---|---|
| PR #372 dependabot ruff bump (`pyproject.toml` only) | skipped | **RUNS** |
| PR #373 the lint fix | skipped | **RUNS** |
| a lockfile-only bump | skipped | **RUNS** |
| a normal python change | RUNS | RUNS |
| a docs-only change | skipped | skipped |

## Contrast to Current Behavior

`python-lint` runs `ruff check`, `ruff format --check` and `mypy`. It was gated on `python_all`, which matched only `**/*.py`. Neither `pyproject.toml` — where ruff and mypy are configured, and where ruff's version is pinned — nor `uv.lock`, which resolves that version, was in the filter.

**That is how `develop` came to be lint-red without anyone noticing.** PR #372 bumped ruff `0.16.0` → `0.16.3` with `pyproject.toml` as its only changed file. The job that would have caught the resulting 74 errors was skipped, because a change to the linter's own version could never trigger the linter. #373 then had to fix a red that CI had never reported — and #373's own green was equally uninformative, since it too changed no `.py` files.

Separately, `documentation-lint` and `validate-documentation-style` declared `needs: ["files-changed", "python-lint"]`. A skipped dependency skips its dependents, so on a docs-only change — where `python-lint` correctly skips — the Docusaurus build and the Vale style check silently skipped with it. Neither uses anything `python-lint` produces.

`validate-documentation-style` also had **no `if:` condition at all**: its only gating was inheriting `python-lint`'s outcome, so it ran whenever Python changed and skipped whenever Python did not, neither of which has anything to do with prose style. It now carries the `documentation` filter directly.

## Discussion: Benefits and Drawbacks

**Benefit:** the class of failure this fixes is the worst kind — CI reporting green because it never ran the check. It cost one PR to notice and another to repair.

**Drawback:** every dependency bump that touches `uv.lock` now runs the Python linters, so bump PRs get slightly slower. That is the intended trade: a bump that changes a linter's version is precisely when you want the linter to run.

**Risk:** low and self-revealing. Adding paths to a filter only ever makes more jobs run, and removing a `needs` edge only ever makes jobs run in more cases — neither can cause a check to be skipped that runs today. If the new `if:` on `validate-documentation-style` is judged too narrow, widening it is a one-line change.

## Changes to the Documentation

None — this changes CI gating only.

## Proposed Release Note Entry

_No release note — CI only._

## Test Plan

- `invoke lint` exits 0.
- `actionlint` output is byte-identical before and after (two pre-existing shellcheck warnings in an unrelated step).
- The job graph is now: `yaml-lint`, `markdown-lint`, `python-lint`, `documentation-lint`, `validate-documentation-style` each depending on `files-changed` alone, each with its own filter.
- **This PR is its own test:** it changes only `.github/**`, so `python-lint` should still skip here. The real proof lands on the next PR that touches `pyproject.toml` or `uv.lock` — and #374, which is rebasing onto this, exercises the docs-job decoupling.

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `develop` branch.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure Python linters run when their config or version changes, and prevent docs jobs from skipping with them. Previously `python-lint` only ran on `.py` changes and docs jobs depended on it; now it also triggers on `pyproject.toml`/`uv.lock` updates and docs jobs depend only on the docs filter.

- Expand `python_all` to include `pyproject.toml` and `uv.lock` so `ruff`/`mypy` run when their config or pinned version changes.
- Remove `python-lint` from `needs` of `documentation-lint` and `validate-documentation-style`; add `if: ...documentation` to `validate-documentation-style`.
- Side effect: dependency bumps touching `uv.lock` will run `python-lint`; intended to catch linter version changes.
- Risk: low; only increases when jobs run, never causes additional skips.

<sup>Written for commit 8dc52349330c4a028f57c0e88e29b66028bc91ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-ansible/pull/375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

