### PR TITLE
feat(inventory): report what a run cost at raised verbosity

### DIFF
--- a/dev/knowledge/inventory-and-lookup.md
+++ b/dev/knowledge/inventory-and-lookup.md
@@ -47,6 +47,32 @@ inventory files against one Infrahub share an entry, and switching `branch`
 would serve the other branch's hosts. The cache is written only on a miss, so an
 entry ages out instead of having its TTL renewed on every run.
 
+### What a run cost
+
+`fetch_and_process` ends by reporting what the run cost, at raised verbosity only:
+
+```text
+Inventory fetch cost: 15 request(s) to Infrahub, 41 related node(s) loaded in 2 batch(es)
+```
+
+The request count comes from a `RequestCounter`
+(`plugins/module_utils/metrics.py`) handed to the SDK as its `custom_recorder`
+when `InfrahubclientWrapper` builds its `Config`. That is the only place a
+truthful count can be taken: the SDK paginates inside `client.filters()`, below
+the wrapper, so counting the wrapper's own calls reports fetch *operations* and
+misses the pages — the part that actually grows with the estate.
+
+Two things to know before reading the number. It counts **every** HTTP
+round-trip, so schema lookups (REST, not GraphQL) are included and the figure is
+legitimately higher than a GraphQL-only count. And a wrapper built through
+`__new__` — which the integration tests do, to skip re-authenticating — has no
+counter attached, so the line reports `unavailable` for requests and still gives
+the peer figures.
+
+It goes out through `Display.v`, which Ansible gates behind `-v`; nothing is
+printed at default verbosity, and a run served entirely from cache never reaches
+this code at all.
+
 String values are passed through `_mark_trusted` before going into the
 inventory — on ansible-core 2.19 this tags plugin-supplied strings as
 trusted-as-template so `ansible-inventory --list` emits plain JSON instead of

--- a/plugins/AGENTS.md
+++ b/plugins/AGENTS.md
@@ -8,7 +8,7 @@ Plugin development context for the `opsmill.infrahub` Ansible collection.
 |-----------|------|-------|-------------|
 | `modules/` | Module stubs | 5 | User-facing interface — DOCUMENTATION + argument specs |
 | `action/` | Action plugins | 3 | Controller-side execution logic |
-| `module_utils/` | Shared utilities | 7 | SDK wrapper, base classes, processors |
+| `module_utils/` | Shared utilities | 8 | SDK wrapper, base classes, processors |
 | `inventory/` | Inventory plugin | 1 | Dynamic inventory from Infrahub |
 | `lookup/` | Lookup plugin | 1 | GraphQL query lookup |
 | `doc_fragments/` | Doc fragments | 1 | Reusable DOCUMENTATION blocks |
@@ -85,6 +85,7 @@ Check at runtime before using:
 | `module_utils/exception.py` | `handle_infrahub_exceptions_decorator` — SDK error mapping |
 | `module_utils/projection.py` | `NodeProjection` — user node spec to the SDK's include/exclude arguments |
 | `module_utils/peers.py` | `PeerWarmer`, `RefillLedger` — bounded peer loading for nested paths |
+| `module_utils/metrics.py` | `RequestCounter` — SDK recorder counting HTTP round-trips for the run-cost report |
 | `module_utils/schema.py` | `SchemaModule` — schema load/check/export |
 | `doc_fragments/fragments.py` | `ModuleDocFragment` — reusable doc blocks |
 

--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 from ansible.module_utils.basic import env_fallback
 from ansible_collections.opsmill.infrahub.plugins.module_utils.exception import handle_infrahub_exceptions_decorator
+from ansible_collections.opsmill.infrahub.plugins.module_utils.metrics import RequestCounter, request_count
 from ansible_collections.opsmill.infrahub.plugins.module_utils.peers import PeerWarmer, RefillLedger
 from ansible_collections.opsmill.infrahub.plugins.module_utils.projection import NodeProjection
 
@@ -113,17 +114,31 @@ if HAS_INFRAHUBCLIENT:
             if not isinstance(validate_certs, bool):
                 raise ValueError(f"validate_certs must be a bool, got {type(validate_certs).__name__}")
 
+            # Handed to the SDK as its recorder so the count is taken below pagination,
+            # where the round-trips actually happen. Held here so callers can read it
+            # back without reaching into the client's config.
+            self.request_counter = RequestCounter()
+
             if branch:
                 self.client = InfrahubClientSync(
                     address=api_endpoint,
                     config=Config(
-                        api_token=token, timeout=timeout, default_branch=branch, tls_insecure=not validate_certs
+                        api_token=token,
+                        timeout=timeout,
+                        default_branch=branch,
+                        tls_insecure=not validate_certs,
+                        custom_recorder=self.request_counter,
                     ),
                 )
             else:
                 self.client = InfrahubClientSync(
                     address=api_endpoint,
-                    config=Config(api_token=token, timeout=timeout, tls_insecure=not validate_certs),
+                    config=Config(
+                        api_token=token,
+                        timeout=timeout,
+                        tls_insecure=not validate_certs,
+                        custom_recorder=self.request_counter,
+                    ),
                 )
             self.display = display
             for method_name in dir(self):
@@ -619,6 +634,8 @@ if HAS_INFRAHUBCLIENT:
                     self.display.warning(error_msg)
                 elif level == "INFO":
                     self.display.v(error_msg)
+                elif level == "VVV":
+                    self.display.vvv(error_msg)
                 elif level == "DEBUG":
                     self.display.debug(error_msg)
 
@@ -934,6 +951,11 @@ if HAS_INFRAHUBCLIENT:
             if not nodes:
                 return None
 
+            # Snapshot rather than read the running total: the counter belongs to the
+            # client, which outlives a single call. Reporting the absolute value would
+            # attribute an earlier run's requests to this one.
+            requests_before = request_count(self.client)
+
             fetched = self._fetch_host_nodes(nodes=nodes, prefetch_relationships=prefetch_relationships)
             if not fetched.nodes:
                 if fetched.failures:
@@ -960,7 +982,7 @@ if HAS_INFRAHUBCLIENT:
                 ),
                 order=Order(disable=True),
             )
-            self._warm_peers(warmer=warmer, fetched=fetched)
+            peer_batches = self._warm_peers(warmer=warmer, fetched=fetched)
 
             # `refill` collects nodes whose attributes the query never carried rather than
             # refetching them one by one. Anything it finds is loaded in one batched pass,
@@ -976,12 +998,105 @@ if HAS_INFRAHUBCLIENT:
                     message=f"Refilling nodes with unqueried attributes: {dict.fromkeys(refill.pending)}",
                     level="DEBUG",
                 )
-                warmer.warm(refill.pending)
+                peer_batches += warmer.warm(refill.pending)
                 host_node_attributes = self._resolve_hosts(
                     fetched=fetched, include_id=include_id, refill=RefillLedger.disabled(), refreshed=True
                 )
 
+            self._report_run_cost(
+                requests_before=requests_before,
+                peer_batches=peer_batches,
+                peers_loaded=len(warmer.loaded),
+                fetched=fetched,
+                warmer=warmer,
+            )
+
             return host_node_attributes
+
+        def _report_run_cost(
+            self,
+            requests_before: int | None,
+            peer_batches: int,
+            peers_loaded: int,
+            fetched: HostFetch,
+            warmer: PeerWarmer,
+        ) -> None:
+            """State what the run cost, at raised verbosity only.
+
+            The point is that the next report of slowness arrives as a number rather
+            than an anecdote. It is deliberately not printed at default verbosity: an
+            inventory run's output belongs to the playbook, not to diagnostics.
+
+            The request count covers every HTTP round-trip, schema lookups included --
+            those are not GraphQL queries but they cost the server the same. When no
+            counter is attached (a wrapper built through ``__new__``, as the tests do)
+            the peer figures are still worth reporting on their own.
+
+            At ``-vvv`` the totals are followed by the breakdown behind them: what each
+            requested kind cost and how far its query was narrowed, and what each peer
+            kind cost. A total that looks wrong is only actionable once you can see
+            which kind produced it.
+
+            Parameters:
+                requests_before (int | None): counter reading taken before this run began,
+                    so the figure reported is this run's cost and not the client's lifetime total.
+                peer_batches (int): how many batched peer fetches were issued.
+                peers_loaded (int): how many related nodes came back.
+                fetched (HostFetch): the host nodes and their projections, for the per-kind lines.
+                warmer (PeerWarmer): carries the per-peer-kind tallies.
+            """
+            requests_now = request_count(self.client)
+            unavailable = requests_before is None or requests_now is None
+            cost = "unavailable" if unavailable else f"{requests_now - requests_before} request(s)"
+            self._handle_display(
+                message=(
+                    f"Inventory fetch cost: {cost} to Infrahub, "
+                    f"{peers_loaded} related node(s) loaded in {peer_batches} batch(es)"
+                ),
+                level="INFO",
+            )
+            for line in self._run_cost_breakdown(fetched=fetched, warmer=warmer):
+                self._handle_display(message=line, level="VVV")
+
+        @staticmethod
+        def _run_cost_breakdown(fetched: HostFetch, warmer: PeerWarmer) -> list[str]:
+            """The per-kind detail behind the run-cost totals.
+
+            Separate from the emitting method so it can be asserted on directly, and so
+            nothing here can raise into a run: this is a diagnostic, and a diagnostic
+            that breaks the thing it reports on is worse than no diagnostic.
+            """
+            lines: list[str] = []
+
+            hosts_by_kind: dict[str, int] = {}
+            for node in fetched.nodes:
+                kind = getattr(getattr(node, "_schema", None), "kind", "unknown")
+                hosts_by_kind[kind] = hosts_by_kind.get(kind, 0) + 1
+
+            for kind in sorted(hosts_by_kind):
+                projection = fetched.projections.get(kind)
+                if projection is None:
+                    # A concrete kind a generic answered with: it has no projection of
+                    # its own, and saying "not narrowed" would be a lie.
+                    detail = "answered via a requested generic"
+                elif not projection.narrowed:
+                    detail = "no include given, full attribute set requested"
+                else:
+                    requested = ", ".join(sorted(projection.roots)) or "none"
+                    excluded = len(projection.exclude or ())
+                    detail = f"requested [{requested}], {excluded} field(s) excluded"
+                lines.append(f"  host kind {kind}: {hosts_by_kind[kind]} node(s), {detail}")
+
+            for kind in sorted(warmer.stats):
+                stat = warmer.stats[kind]
+                detail = f"{stat['requested']} id(s) referenced, {stat['batches']} batch(es), {stat['loaded']} loaded"
+                if stat["failed"]:
+                    detail += f", {stat['failed']} batch(es) failed"
+                lines.append(f"  peer kind {kind}: {detail}")
+
+            if not lines:
+                return []
+            return ["Inventory fetch cost, by kind:", *lines]
 
         def _fetch_host_nodes(self, nodes: dict[str, Any], prefetch_relationships: bool | None) -> HostFetch:
             """Fetch every requested kind, narrowed to what the user actually asked for.
@@ -1075,16 +1190,19 @@ if HAS_INFRAHUBCLIENT:
 
             return fetched
 
-        def _warm_peers(self, warmer: PeerWarmer, fetched: HostFetch) -> None:
+        def _warm_peers(self, warmer: PeerWarmer, fetched: HostFetch) -> int:
             """Load the peers that nested paths are about to read.
 
             Only ids the host nodes reference are fetched, and only where the inline peer
             payload came back short, so this costs one request per page of peers rather
             than one pass over every peer kind in the database.
+
+            Returns:
+                int: how many peer batches were issued.
             """
             referenced = warmer.collect(nodes=fetched.nodes, attrs_by_kind=fetched.attrs_by_kind)
             if not referenced:
-                return
+                return 0
 
             self._handle_display(
                 message=f"Loading referenced peers: {dict.fromkeys(referenced)}",
@@ -1093,7 +1211,7 @@ if HAS_INFRAHUBCLIENT:
             # No schema fetch for the peer kinds: `resolve_node_mapping` reads a node's
             # own `_schema`, never the `schemas` mapping it is handed, so loading them
             # here would be a round-trip nothing reads back.
-            warmer.warm(referenced)
+            return warmer.warm(referenced)
 
         def _resolve_hosts(
             self,

--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -965,7 +965,9 @@ if HAS_INFRAHUBCLIENT:
                     # playbook would quietly no-op against zero hosts. Fail loudly instead.
                     detail = "; ".join(f"{kind}: {why}" for kind, why in sorted(fetched.failures.items()))
                     raise RuntimeError(f"No nodes could be fetched. Failures -- {detail}")
-                # Every requested kind answered, and the answer was empty.
+                # Every requested kind answered, and the answer was empty. Still
+                # report: the schema lookups and the empty query cost round-trips.
+                self._report_run_cost(requests_before=requests_before, fetched=fetched)
                 return None
 
             warmer = PeerWarmer(
@@ -1016,10 +1018,10 @@ if HAS_INFRAHUBCLIENT:
         def _report_run_cost(
             self,
             requests_before: int | None,
-            peer_batches: int,
-            peers_loaded: int,
             fetched: HostFetch,
-            warmer: PeerWarmer,
+            peer_batches: int = 0,
+            peers_loaded: int = 0,
+            warmer: PeerWarmer | None = None,
         ) -> None:
             """State what the run cost, at raised verbosity only.
 
@@ -1040,26 +1042,31 @@ if HAS_INFRAHUBCLIENT:
             Parameters:
                 requests_before (int | None): counter reading taken before this run began,
                     so the figure reported is this run's cost and not the client's lifetime total.
-                peer_batches (int): how many batched peer fetches were issued.
-                peers_loaded (int): how many related nodes came back.
                 fetched (HostFetch): the host nodes and their projections, for the per-kind lines.
-                warmer (PeerWarmer): carries the per-peer-kind tallies.
+                peer_batches (int): how many batched peer fetches came back.
+                peers_loaded (int): how many nodes those batches loaded.
+                warmer (PeerWarmer | None): carries the per-kind tallies. ``None`` when
+                    the query matched no hosts, so nothing was warmed.
             """
             requests_now = request_count(self.client)
             unavailable = requests_before is None or requests_now is None
             cost = "unavailable" if unavailable else f"{requests_now - requests_before} request(s)"
-            self._handle_display(
-                message=(
-                    f"Inventory fetch cost: {cost} to Infrahub, "
-                    f"{peers_loaded} related node(s) loaded in {peer_batches} batch(es)"
-                ),
-                level="INFO",
+            # "node(s)", not "related node(s)": the refill pass shares this warmer, so
+            # host nodes are counted here too.
+            message = (
+                f"Inventory fetch cost: {cost} to Infrahub, {peers_loaded} node(s) loaded in {peer_batches} batch(es)"
             )
+            failed_batches = sum(stat["failed"] for stat in warmer.stats.values()) if warmer else 0
+            if failed_batches:
+                # A failed batch cost a round-trip too, so it belongs in the cost line
+                # rather than only in the -vvv breakdown.
+                message += f", {failed_batches} batch(es) failed"
+            self._handle_display(message=message, level="INFO")
             for line in self._run_cost_breakdown(fetched=fetched, warmer=warmer):
                 self._handle_display(message=line, level="VVV")
 
         @staticmethod
-        def _run_cost_breakdown(fetched: HostFetch, warmer: PeerWarmer) -> list[str]:
+        def _run_cost_breakdown(fetched: HostFetch, warmer: PeerWarmer | None) -> list[str]:
             """The per-kind detail behind the run-cost totals.
 
             Separate from the emitting method so it can be asserted on directly, and so
@@ -1087,12 +1094,16 @@ if HAS_INFRAHUBCLIENT:
                     detail = f"requested [{requested}], {excluded} field(s) excluded"
                 lines.append(f"  host kind {kind}: {hosts_by_kind[kind]} node(s), {detail}")
 
-            for kind in sorted(warmer.stats):
-                stat = warmer.stats[kind]
+            for kind in sorted(warmer.stats if warmer else {}):
+                stat = warmer.stats[kind]  # type: ignore[union-attr]
                 detail = f"{stat['requested']} id(s) referenced, {stat['batches']} batch(es), {stat['loaded']} loaded"
                 if stat["failed"]:
                     detail += f", {stat['failed']} batch(es) failed"
-                lines.append(f"  peer kind {kind}: {detail}")
+                # A host kind here came from the refill pass, not a relationship.
+                # `RefillLedger` keys on the same `_schema.kind` counted above, so
+                # membership is what tells the two apart.
+                label = "refilled host kind" if kind in hosts_by_kind else "peer kind"
+                lines.append(f"  {label} {kind}: {detail}")
 
             if not lines:
                 return []

--- a/plugins/module_utils/metrics.py
+++ b/plugins/module_utils/metrics.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 Opsmill
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""What a run cost, counted where the cost is actually incurred.
+
+The inventory's expense is round-trips, and the number that matters is the one a
+network trace would show. That number is not visible from the collection: the SDK
+paginates inside ``client.filters()``, below ``InfrahubclientWrapper``, so counting
+the calls the wrapper makes reports fetch *operations* and misses exactly the thing
+that varies.
+
+The SDK's ``Recorder`` protocol is invoked once per HTTP response, below pagination.
+Implementing it is therefore the only place a truthful count can be taken, and it is
+a supported extension point rather than a monkeypatch -- nothing is reassigned on the
+client at runtime.
+
+``httpx`` is annotated under ``TYPE_CHECKING`` so this module imports cleanly without
+the SDK installed, the way every plugin file here has to.
+"""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import httpx
+
+
+class RequestCounter:
+    """Counts HTTP responses the SDK receives.
+
+    Structurally a ``Recorder``: the SDK's protocol is runtime-checkable and asks
+    only for ``record(response)``, so this satisfies it without importing it.
+
+    The count covers *every* response, not only GraphQL ones -- schema lookups go
+    over REST and cost a round-trip just the same. Reporting the smaller,
+    GraphQL-only figure would understate what the run actually asked of the server.
+    """
+
+    def __init__(self) -> None:
+        self.responses = 0
+
+    def record(self, response: httpx.Response) -> None:  # noqa: ARG002
+        """Called by the SDK for each response. The response itself is not retained."""
+        self.responses += 1
+
+    def reset(self) -> None:
+        """Zero the counter. Useful when one client serves several measured runs."""
+        self.responses = 0
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(responses={self.responses})"
+
+
+def request_count(client_wrapper: Any) -> int | None:
+    """The responses counted so far, or ``None`` when no counter is attached.
+
+    A wrapper built through ``__new__`` -- which the integration tests do, to skip
+    re-authenticating -- has no counter. Callers report what they can rather than
+    failing over a missing diagnostic.
+    """
+    counter = getattr(client_wrapper, "request_counter", None)
+    responses = getattr(counter, "responses", None)
+    return responses if isinstance(responses, int) else None

--- a/plugins/module_utils/metrics.py
+++ b/plugins/module_utils/metrics.py
@@ -46,10 +46,6 @@ class RequestCounter:
         """Called by the SDK for each response. The response itself is not retained."""
         self.responses += 1
 
-    def reset(self) -> None:
-        """Zero the counter. Useful when one client serves several measured runs."""
-        self.responses = 0
-
     def __repr__(self) -> str:
         return f"{type(self).__name__}(responses={self.responses})"
 

--- a/plugins/module_utils/peers.py
+++ b/plugins/module_utils/peers.py
@@ -239,7 +239,8 @@ class PeerWarmer:
             referenced: concrete peer kind to the ids to fetch.
 
         Returns:
-            int: how many fetch calls were issued.
+            int: how many fetch calls came back. A failed one lands in
+                ``stats[kind]["failed"]`` instead.
         """
         calls = 0
         for kind, ids in referenced.items():
@@ -258,18 +259,23 @@ class PeerWarmer:
                         parallel=False,
                         order=self.order,
                     )
+                    if loaded is None:
+                        # None means the wrapper's exception decorator swallowed the
+                        # failure. Counting it as a batch that worked would hide it.
+                        stat["failed"] += 1
+                        continue
                     calls += 1
                     stat["batches"] += 1
-                    # Record the ids that actually came back, not the ids asked for.
-                    # `fetch` returns None when the wrapper's exception decorator
-                    # swallowed the failure, and even a successful call can return
-                    # fewer nodes than requested -- a peer deleted between the host
-                    # query and this one, or hidden by permissions. Marking those as
-                    # loaded would tell RefillLedger their empty attributes are
-                    # genuine nulls and suppress the retry that would notice.
-                    for node in loaded or []:
+                    # Record the ids that came back, not the ids asked for: a peer can
+                    # vanish between the host query and this one, and marking it loaded
+                    # would tell RefillLedger its empty attributes are genuine nulls.
+                    #
+                    # Once per id, not once per return -- `warm` runs twice a run, and
+                    # double-counting would push the by-kind tally past the deduplicated
+                    # total the summary reports.
+                    for node in loaded:
                         node_id = getattr(node, "id", None)
-                        if node_id:
+                        if node_id and node_id not in self.loaded:
                             self.loaded.add(node_id)
                             stat["loaded"] += 1
                 except Exception as exc:

--- a/plugins/module_utils/peers.py
+++ b/plugins/module_utils/peers.py
@@ -120,6 +120,10 @@ class PeerWarmer:
         # Ids fetched in full this run, so a ``RefillLedger`` can tell a genuine null
         # from an attribute the query never carried.
         self.loaded: set[str] = set()
+        # Per-kind tallies for the raised-verbosity cost breakdown. Accumulated across
+        # both warming passes (the initial one and the refill), because a peer kind can
+        # legitimately appear in each.
+        self.stats: dict[str, dict[str, int]] = {}
 
     @staticmethod
     def _nested_roots(attrs: list[str]) -> dict[str, tuple[str, ...]]:
@@ -240,6 +244,8 @@ class PeerWarmer:
         calls = 0
         for kind, ids in referenced.items():
             ordered = sorted(ids)
+            stat = self.stats.setdefault(kind, {"requested": 0, "batches": 0, "loaded": 0, "failed": 0})
+            stat["requested"] += len(ordered)
             for start in range(0, len(ordered), self.page_size):
                 chunk = ordered[start : start + self.page_size]
                 try:
@@ -253,6 +259,7 @@ class PeerWarmer:
                         order=self.order,
                     )
                     calls += 1
+                    stat["batches"] += 1
                     # Record the ids that actually came back, not the ids asked for.
                     # `fetch` returns None when the wrapper's exception decorator
                     # swallowed the failure, and even a successful call can return
@@ -264,7 +271,9 @@ class PeerWarmer:
                         node_id = getattr(node, "id", None)
                         if node_id:
                             self.loaded.add(node_id)
+                            stat["loaded"] += 1
                 except Exception as exc:
+                    stat["failed"] += 1
                     if self.on_error:
                         self.on_error(kind, exc)
         return calls

--- a/specs/001-inventory-fetch-performance/checklists/requirements.md
+++ b/specs/001-inventory-fetch-performance/checklists/requirements.md
@@ -1,0 +1,50 @@
+# Specification Quality Checklist: Dynamic Inventory Fetch Performance
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+
+**Created**: 2026-08-23
+
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This specification is **retroactive**: it describes work already implemented and measured. Success
+  criteria carry real measured numbers rather than targets, and the "identical output" requirement
+  (FR-018, SC-005) was verified byte-for-byte across four inventory shapes before the spec was written.
+- **FR-020 and SC-009** were added by `/speckit.clarify` (session 2026-08-23) and implemented by
+  `/speckit.implement` the same day: a run reports its own request count and related-node count at
+  raised verbosity. Every requirement in the spec now describes delivered, verified behaviour.
+- Clarification also fixed the spec's vocabulary: it now uses **node** / **node type** / **related node**,
+  matching the `nodes:` key users write, with **host** reserved for the Ansible inventory entry.
+- Two items were rewritten during validation:
+  - **FR-006** originally named "the configured page size", which leaked a connection setting into a
+    functional requirement. Restated in terms of a page of results.
+  - **FR-017** originally said the timeout must be "long enough", which is not testable. Restated with
+    the concrete floor (60 seconds).
+- Zero clarification markers were needed. The feature description was terse, but the work it refers to
+  is complete and measured, so every gap had a factual answer rather than an open question.

--- a/specs/001-inventory-fetch-performance/checklists/requirements.md
+++ b/specs/001-inventory-fetch-performance/checklists/requirements.md
@@ -8,7 +8,7 @@
 
 ## Content Quality
 
-- [x] No implementation details (languages, frameworks, APIs)
+- [ ] No implementation details (languages, frameworks, APIs) — **one deliberate exception, FR-020**; see Notes
 - [x] Focused on user value and business needs
 - [x] Written for non-technical stakeholders
 - [x] All mandatory sections completed
@@ -29,7 +29,7 @@
 - [x] All functional requirements have clear acceptance criteria
 - [x] User scenarios cover primary flows
 - [x] Feature meets measurable outcomes defined in Success Criteria
-- [x] No implementation details leak into specification
+- [ ] No implementation details leak into specification — **FR-020 excepted, deliberately**; see Notes
 
 ## Notes
 
@@ -37,8 +37,15 @@
   criteria carry real measured numbers rather than targets, and the "identical output" requirement
   (FR-018, SC-005) was verified byte-for-byte across four inventory shapes before the spec was written.
 - **FR-020 and SC-009** were added by `/speckit.clarify` (session 2026-08-23) and implemented by
-  `/speckit.implement` the same day: a run reports its own request count and related-node count at
-  raised verbosity. Every requirement in the spec now describes delivered, verified behaviour.
+  `/speckit.implement` the same day: a run reports its own request count, the nodes it loaded beyond
+  the hosts, and the batches that took, at raised verbosity. Every requirement in the spec now describes delivered, verified behaviour.
+- **FR-020 names machinery on purpose, and these boxes are unchecked to say so.** "Every HTTP
+  round-trip, schema lookups included, so it is legitimately higher than a GraphQL-only count" is
+  API language in a spec that otherwise avoids it. It stays because the alternative is worse: a
+  reader told only that the run "reports how many requests it sent" will compare the number against
+  the GraphQL queries they can see, find it higher, and file the report as a bug. The requirement is
+  about a number's meaning, and the meaning does not survive being made technology-agnostic. Every
+  other requirement in the spec holds the line.
 - Clarification also fixed the spec's vocabulary: it now uses **node** / **node type** / **related node**,
   matching the `nodes:` key users write, with **host** reserved for the Ansible inventory entry.
 - Two items were rewritten during validation:

--- a/specs/001-inventory-fetch-performance/contracts/inventory-options.md
+++ b/specs/001-inventory-fetch-performance/contracts/inventory-options.md
@@ -59,8 +59,10 @@ binding statement, verified byte-for-byte across four definition shapes.
 | Related-node batch fails | `warning` | Names the type; hosts still produced, attribute empty; run succeeds (FR-019) |
 | No hosts fetched, at least one type failed | **error** | Run fails, message names each type and reason (FR-015) |
 | No hosts fetched, nothing failed | — | Succeeds, no hosts, no error (FR-016) |
-| Run cost | `-v` | Requests sent, related nodes loaded, and how many batches it took (FR-020) |
+| Run cost | `-v` | Requests sent, nodes loaded beyond the hosts, and how many batches that took; failed batches named when there were any (FR-020) |
+| Run cost | `-vvv` | The `-v` totals, plus the breakdown behind them: per host kind, its node count and how far its query was narrowed; per peer kind, ids referenced, batches, nodes loaded, and batches failed. A refilled host kind is named as one, not as a peer kind |
 | Run cost | default verbosity | Silent (FR-020) |
+| Run cost | run served entirely from cache | Silent at every verbosity — nothing was fetched (FR-020) |
 
 ## Cache contract
 

--- a/specs/001-inventory-fetch-performance/contracts/inventory-options.md
+++ b/specs/001-inventory-fetch-performance/contracts/inventory-options.md
@@ -1,0 +1,76 @@
+# Contract: Inventory Plugin Interface
+
+The collection's external interface for this feature is the inventory plugin's YAML option schema —
+what a user writes in `*.infrahub.yml` — plus what the run emits back. Source of truth is the
+`DOCUMENTATION` block in `plugins/inventory/inventory.py`; the reference MDX under
+`docs/docs/references/plugins/` is generated from it by `invoke generate-doc` and is never hand-edited.
+
+## Input contract
+
+```yaml
+plugin: opsmill.infrahub.inventory
+api_endpoint: http://localhost:8000     # or INFRAHUB_ADDRESS
+token: <token>                          # or INFRAHUB_API_TOKEN; no_log
+branch: main
+validate_certs: true
+timeout: 60                             # FR-017 — default raised from 10
+prefetch_relationships: true
+
+nodes:
+  InfraDevice:                          # node type
+    include:                            # attribute selection; dotted paths allowed
+      - name
+      - platform.ansible_network_os
+      - primary_address.address
+      - site.name
+      - interfaces
+    exclude: []
+    filters: {}
+
+compose: {}
+keyed_groups: []
+hostnames: []
+```
+
+### Guarantees
+
+| Guarantee | Requirement |
+|---|---|
+| No option added, removed, or renamed by this feature | Spec Out of Scope |
+| `timeout` default is at least 60 | FR-017 |
+| `include` narrows what is requested; omitting it preserves the historical wide query | FR-003, FR-004 |
+| Selections are per node type, not global | FR-003, FR-004 |
+| A dotted path resolves even when the relationship declares a broad peer type | FR-009 |
+| A path naming only a relationship (no attribute) yields peer ids without fetching peers | FR-010 |
+| For any definition, produced hosts and host variables are unchanged from before this feature | FR-018 |
+
+## Output contract
+
+### Inventory
+
+Unchanged. Hosts, host variables, groups, and `keyed_groups` behave exactly as before — FR-018 is the
+binding statement, verified byte-for-byte across four definition shapes.
+
+### Diagnostics
+
+| Condition | Level | Behaviour |
+|---|---|---|
+| Node type's schema not found | `warning` | Skipped; other types still resolve (FR-014) |
+| Related-node batch fails | `warning` | Names the type; hosts still produced, attribute empty; run succeeds (FR-019) |
+| No hosts fetched, at least one type failed | **error** | Run fails, message names each type and reason (FR-015) |
+| No hosts fetched, nothing failed | — | Succeeds, no hosts, no error (FR-016) |
+| Run cost | `-v` | Requests sent, related nodes loaded, and how many batches it took (FR-020) |
+| Run cost | default verbosity | Silent (FR-020) |
+
+## Cache contract
+
+Not a user-facing option, but observable: two definitions differing only in branch, or only in node
+selection, occupy distinct cache entries (FR-011). Entries written under an older
+`CACHE_SCHEMA_VERSION` are not reused (FR-012). The cache is written only on a run that fetched
+(FR-013).
+
+## Compatibility
+
+No migration. Existing inventory files keep working unchanged and get the improvement without edits.
+The only user-visible default change is `timeout`, 10 → 60, which lengthens the ceiling on a run that
+would previously have aborted; it does not lengthen a run that succeeds.

--- a/specs/001-inventory-fetch-performance/data-model.md
+++ b/specs/001-inventory-fetch-performance/data-model.md
@@ -1,0 +1,126 @@
+# Phase 1 Data Model: Dynamic Inventory Fetch Performance
+
+The spec's Key Entities are conceptual. This maps each to the thing that actually carries it, the fields
+that matter, and the rules the requirements impose on it.
+
+## Node
+
+A record in Infrahub — a device, an address, a site. Carried by the SDK's `InfrahubNodeSync`.
+
+| Field | Meaning | Notes |
+|---|---|---|
+| `id` | Stable identifier | Always queried; the key peers are batched by |
+| `hfid` | Human-friendly identifier | Always queried |
+| `display_label` | Rendered label | Always queried; usable as a hostname source |
+| *attributes* | Named values on the node | What a definition selects from |
+| *relationships* | Links to other nodes | Peers may arrive inline, or as bare ids |
+
+### Rules
+
+- `id`, `hfid`, `display_label` are never narrowed away (`ALWAYS_QUERIED` in `projection.py`).
+- An attribute whose value is `None` is absent; `False`, `0`, and `""` are **present**. This distinction
+  is load-bearing: treating a falsy value as absent is what produced one refetch per node (FR-002).
+
+## Node type
+
+The key a user writes under `nodes:` in the inventory definition. Infrahub calls it a *kind*.
+
+### Rules
+
+- Each node type carries its own attribute selection, independently of the others (FR-003/FR-004 apply
+  per type, not globally).
+- A node type whose schema cannot be found is skipped, recorded in `HostFetch.failures`, and does not
+  abort the run (FR-014).
+
+## Attribute selection → `NodeProjection`
+
+`plugins/module_utils/projection.py`. Translates what the user wrote into what the SDK honours.
+
+| Field | Meaning |
+|---|---|
+| `attrs` | The full selection, dotted paths included (`site.name`) |
+| `roots` | First path segment of each selection — what a query can actually narrow on |
+| `include` | Roots that exist on the schema; opts cardinality-many relationships in |
+| `exclude` | Complement of `roots` against the schema, merged with any user `exclude` |
+| `narrowed` | Whether the user gave a selection at all |
+
+### Rules
+
+- No selection → `narrowed = False`, and the historical wide query is preserved unchanged (FR-004).
+- A selection → `exclude` carries the narrowing, because `include` alone does not narrow (see R5).
+- `projected(root_attr)` answers "was this attribute asked for?" and is what stops the refill ledger from
+  queueing a node for an attribute nobody wanted.
+
+## Related node → `PeerWarmer` / `RefillLedger`
+
+`plugins/module_utils/peers.py`.
+
+`PeerWarmer` state:
+
+| Field | Meaning |
+|---|---|
+| `store` | The SDK's `NodeStore`, where prefetched peers land |
+| `page_size` | `pagination_size - 1` (see R3) |
+| `loaded` | Ids that actually came back — not ids that were asked for |
+
+`RefillLedger` state:
+
+| Field | Meaning |
+|---|---|
+| `projections` | Per-type `NodeProjection`, to tell "not asked for" from "asked for and missing" |
+| `already_loaded` | Shared with `PeerWarmer.loaded`; a peer fetched in full is never re-queued |
+| `pending` | Node type → set of ids still needing a refill pass |
+
+### Rules
+
+- `collect()` computes the wanted-attribute set **per node type**, not per node.
+- A peer is fetched only if its wanted attributes are not already satisfied in the store (FR-007).
+- `warm()` records only ids present in the response (FR-008). Recording what was *requested* would mark
+  a missing peer as loaded and silently suppress its refill.
+- A batch that raises calls `on_error`, which warns and continues; hosts referencing it are still
+  produced with the attribute empty (FR-019).
+- A relationship whose selection asks only for the peer's id short-circuits: the id is read off the
+  relationship and the peer is never fetched (FR-010).
+
+## Host fetch → `HostFetch`
+
+`plugins/module_utils/infrahub_utils.py`. A dataclass (not a tuple — its dict and list fields are
+mutated in place during the fetch loop, and readability at the call sites matters more than immutability
+here).
+
+| Field | Meaning |
+|---|---|
+| `nodes` | Fetched host nodes across all types |
+| `schemas` | Node type → schema |
+| `attrs_by_kind` | Node type → selection |
+| `projections` | Node type → `NodeProjection` |
+| `failures` | Node type → why it failed |
+
+### Rules
+
+- `nodes` empty **and** `failures` non-empty → raise, naming every failure (FR-015).
+- `nodes` empty and `failures` empty → succeed with no hosts (FR-016).
+
+## Cache entry
+
+Ansible's cache plugin holds the value; this feature defines only the key.
+
+### Rules
+
+- Key material: API endpoint, branch, node selection, and `CACHE_SCHEMA_VERSION` (FR-011, FR-012).
+- Written only when the run actually fetched from the API (FR-013).
+
+## Run cost report — *not yet implemented*
+
+Required by FR-020 / SC-009. Per R1, carried by a counting `Recorder` passed as `Config.custom_recorder`
+from `InfrahubclientWrapper`.
+
+| Field | Meaning |
+|---|---|
+| `requests` | HTTP responses observed — the true count, below pagination |
+| `peers_loaded` | Related nodes loaded; `PeerWarmer.warm()` already returns its call count today and discards it in `_warm_peers` |
+
+### Rules
+
+- Emitted at raised verbosity only (`_handle_display(level="INFO")` → `display.v()`); silent at default.
+- A run served entirely from cache fetches nothing and so reports nothing.

--- a/specs/001-inventory-fetch-performance/data-model.md
+++ b/specs/001-inventory-fetch-performance/data-model.md
@@ -110,17 +110,23 @@ Ansible's cache plugin holds the value; this feature defines only the key.
 - Key material: API endpoint, branch, node selection, and `CACHE_SCHEMA_VERSION` (FR-011, FR-012).
 - Written only when the run actually fetched from the API (FR-013).
 
-## Run cost report — *not yet implemented*
+## Run cost report
 
-Required by FR-020 / SC-009. Per R1, carried by a counting `Recorder` passed as `Config.custom_recorder`
-from `InfrahubclientWrapper`.
+Required by FR-020 / SC-009, delivered in PR #381. Per R1, carried by a counting `Recorder` passed as
+`Config.custom_recorder` from `InfrahubclientWrapper`.
 
 | Field | Meaning |
 |---|---|
 | `requests` | HTTP responses observed — the true count, below pagination |
-| `peers_loaded` | Related nodes loaded; `PeerWarmer.warm()` already returns its call count today and discards it in `_warm_peers` |
+| `peers_loaded` | Nodes the batched passes loaded on top of the hosts themselves, deduplicated across both passes (`len(PeerWarmer.loaded)`) |
+| `peer_batches` | Batches that came back, summed over both passes. Batches that failed are counted separately and reported as their own clause |
 
 ### Rules
 
-- Emitted at raised verbosity only (`_handle_display(level="INFO")` → `display.v()`); silent at default.
-- A run served entirely from cache fetches nothing and so reports nothing.
+- Totals at raised verbosity (`_handle_display(level="INFO")` → `display.v()`), the by-kind breakdown
+  behind them one level deeper (`level="VVV"` → `display.vvv()`); silent at default.
+- Reported on any run that fetched, a run whose query matched no hosts included: the schema lookups and
+  the empty node query were round-trips, and that is exactly when someone asks whether the run asked.
+- A run served entirely from cache fetches nothing and so reports nothing (FR-020 says as much).
+- A host kind that reaches the warmer got there through the refill pass, not a relationship, and the
+  breakdown names it as such rather than calling it a peer kind.

--- a/specs/001-inventory-fetch-performance/plan.md
+++ b/specs/001-inventory-fetch-performance/plan.md
@@ -10,7 +10,7 @@ Cut the cost of building a dynamic inventory from *proportional to the database*
 
 Four defects compounded into the reported slowness: related nodes were fetched a whole type at a time rather than by the ids actually referenced; the attribute selection a user wrote was never translated into a narrower request; any attribute that came back empty triggered a refetch of the node that owned it, one request per node; and the cache key ignored the branch and the node selection. The refetch turned out to be load-bearing — it was the only thing making attributes resolve when a relationship declares a broad peer type — so removing it required replacing it with a bounded, batched warm-up pass.
 
-**Status of this plan**: 19 of the 20 functional requirements describe work already implemented, measured, and green in PR #374. The forward work is **FR-020 / SC-009** — a run reporting its own cost at raised verbosity — which was added during `/speckit.clarify` and does not exist in the code. Phase 0 research below resolves the one open design question it carries.
+**Status of this plan**: all 20 functional requirements are implemented. Nineteen shipped in PR #374, measured and green. The twentieth, **FR-020 / SC-009** — a run reporting its own cost at raised verbosity — was added during `/speckit.clarify` and ships in PR #381, built to the design Phase 0 research below settled.
 
 ## Technical Context
 
@@ -20,7 +20,7 @@ Four defects compounded into the reported slowness: related nodes were fetched a
 
 **Storage**: N/A for the fetch path. Inventory results may be persisted through Ansible's own cache plugin interface (`jsonfile` by default); this feature only defines the cache *key*, never the backend.
 
-**Testing**: `pytest` unit tests with a mocked SDK client; `ansible-test sanity` for plugin compliance; `pytest` integration tests against a live Infrahub via `infrahub-testcontainers`, split by marker into `integration` (PR gate) and `measurement` (scheduled only — the schema-convergence step is too slow for a standard runner)
+**Testing**: `pytest` unit tests with a mocked SDK client; `ansible-test sanity` for plugin compliance; `pytest` integration tests against a live Infrahub via `infrahub-testcontainers`, split by marker into `integration` and `measurement`. Neither gates a pull request: both run on the nightly schedule and manual dispatch only, because the schema-convergence step is too slow for a standard runner. PRs are gated by `ansible-test sanity`, `ansible-lint` and the unit-test job
 
 **Target Platform**: Ansible controller (Linux, macOS)
 
@@ -94,7 +94,7 @@ tests/
 └── integration/
     ├── inventory/schema.py                                  # generic-peer test schema
     └── processor/
-        ├── test_fetch_and_process_integration.py            # PR gate: correctness + gross-regression counter
+        ├── test_fetch_and_process_integration.py            # nightly: correctness + gross-regression counter
         └── test_fetch_roundtrip_measurement.py              # scheduled: per-shape measured budgets
 ```
 

--- a/specs/001-inventory-fetch-performance/plan.md
+++ b/specs/001-inventory-fetch-performance/plan.md
@@ -1,0 +1,108 @@
+# Implementation Plan: Dynamic Inventory Fetch Performance
+
+**Branch**: `perf/inventory-projection-and-peer-batching` (feature id `001-inventory-fetch-performance`) | **Date**: 2026-08-23 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/001-inventory-fetch-performance/spec.md`
+
+## Summary
+
+Cut the cost of building a dynamic inventory from *proportional to the database* to *proportional to what was asked for*, without changing a single byte of the inventory produced.
+
+Four defects compounded into the reported slowness: related nodes were fetched a whole type at a time rather than by the ids actually referenced; the attribute selection a user wrote was never translated into a narrower request; any attribute that came back empty triggered a refetch of the node that owned it, one request per node; and the cache key ignored the branch and the node selection. The refetch turned out to be load-bearing — it was the only thing making attributes resolve when a relationship declares a broad peer type — so removing it required replacing it with a bounded, batched warm-up pass.
+
+**Status of this plan**: 19 of the 20 functional requirements describe work already implemented, measured, and green in PR #374. The forward work is **FR-020 / SC-009** — a run reporting its own cost at raised verbosity — which was added during `/speckit.clarify` and does not exist in the code. Phase 0 research below resolves the one open design question it carries.
+
+## Technical Context
+
+**Language/Version**: Python >=3.11, <3.15 (`pyproject.toml`)
+
+**Primary Dependencies**: `ansible-core>=2.19.11rc1`; `infrahub-sdk[all]>=1.19.0,<2.0` (synchronous client only)
+
+**Storage**: N/A for the fetch path. Inventory results may be persisted through Ansible's own cache plugin interface (`jsonfile` by default); this feature only defines the cache *key*, never the backend.
+
+**Testing**: `pytest` unit tests with a mocked SDK client; `ansible-test sanity` for plugin compliance; `pytest` integration tests against a live Infrahub via `infrahub-testcontainers`, split by marker into `integration` (PR gate) and `measurement` (scheduled only — the schema-convergence step is too slow for a standard runner)
+
+**Target Platform**: Ansible controller (Linux, macOS)
+
+**Project Type**: Ansible collection — inventory plugin plus shared `module_utils`
+
+**Performance Goals**: The invariant of FR-001 — request count determined by node types, pages, and distinct related-node types, never by host count. Measured on a ~650-host estate: 102.71s → 3.23s, 700 → 15 requests, 3758 KB → 1555 KB.
+
+**Constraints**: Output must be byte-identical to the previous behaviour (FR-018). Synchronous SDK only. No new user-facing configuration option. All Infrahub access mediated by `InfrahubclientWrapper`.
+
+**Scale/Scope**: Measured at 652 hosts (one type) and 1508 hosts (two types). No maximum estate size is specified — see the spec's Assumptions on why a host-count ceiling would mislead.
+
+## Constitution Check
+
+*GATE: evaluated against `.specify/memory/constitution.md` v1.1.0.*
+
+| Principle | Gate | Verdict |
+|---|---|---|
+| I — Ansible Collection Standards | New `module_utils` files carry the copyright header, GPLv3 reference, `from __future__` imports, and `__metaclass__ = type`; `ansible-test sanity` passes | **PASS** — verified on `projection.py` and `peers.py`; sanity matrix green on PR #374 |
+| II — Two Plugin Patterns | No new plugin; no hybrid pattern introduced | **PASS** — the inventory plugin keeps its shape; new code is shared `module_utils` |
+| III — Idempotency and State Management | Applies to modules that mutate Infrahub | **N/A** — the inventory path is read-only, makes no mutations, and reports no `changed` |
+| IV — SDK Abstraction Layer | All API access through `InfrahubclientWrapper`; no ad-hoc `InfrahubClientSync`; sync only; conditional import guard | **PASS WITH DEVIATION** — see Complexity Tracking. Fetching goes through the wrapper (`PeerWarmer` is handed `self.client.fetch_nodes`). Reads of the client's *node store* and `pagination_size` reach past the wrapper; this pattern pre-dates the feature and was extended by it |
+| V — Test Coverage and Quality Gates | Sanity + unit + integration; `invoke generate-doc` after any docstring change | **PASS** — 106 unit tests, 14 integration tests; the `timeout` docstring default change (10 → 60) was followed by `invoke generate-doc` |
+
+### Post-design re-check
+
+Re-evaluated after Phase 1. The one design decision this plan introduces — a counting `Recorder` passed
+as `Config.custom_recorder` from `InfrahubclientWrapper` (research.md R1) — **improves** Principle IV
+compliance rather than straining it: the wrapper stays the sole constructor and configurer of the SDK
+client, and the rejected alternative (reassigning `client.execute_graphql` at runtime) was the one that
+would have bypassed it. No new gate violations. The Complexity Tracking entries below are unchanged from
+the pre-Phase-0 evaluation.
+
+**Constitution staleness noted (not a violation of this feature):** the constitution's Constraints section states Python `>=3.10,<3.14`, `ansible-core>=2.17.7rc1`, and `infrahub-sdk>=1.5,<2.0`. The repository actually pins `>=3.11,<3.15`, `>=2.19.11rc1`, and `>=1.19.0,<2.0`. This feature complies with the real pins. Reconciling the constitution is out of scope here and belongs in an explicit constitution update.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-inventory-fetch-performance/
+├── plan.md              # This file
+├── spec.md              # Feature specification (20 FR, 9 SC, 4 clarifications)
+├── research.md          # Phase 0 output — resolves the FR-020 design question
+├── data-model.md        # Phase 1 output — entities and their real carriers
+├── quickstart.md        # Phase 1 output — how to reproduce and verify the numbers
+├── contracts/
+│   └── inventory-options.md   # The plugin's user-facing contract
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (all items pass)
+└── tasks.md             # Phase 2 output — NOT created by /speckit.plan
+```
+
+### Source Code (repository root)
+
+```text
+plugins/
+├── inventory/
+│   └── inventory.py            # Cache key (FR-011..FR-013), timeout default (FR-017), display wiring
+└── module_utils/
+    ├── infrahub_utils.py       # InfrahubclientWrapper, InfrahubNodesProcessor, HostFetch; orchestration
+    ├── projection.py           # NodeProjection — user selection to SDK include/exclude (FR-003, FR-004)
+    └── peers.py                # PeerWarmer, RefillLedger — bounded batched peer loading (FR-005..FR-010)
+
+tests/
+├── unit/plugins/
+│   ├── inventory/test_inventory_cache_key.py
+│   └── module_utils/
+│       ├── test_projection.py
+│       ├── test_peers.py
+│       └── test_fetch_and_process_resolution.py
+└── integration/
+    ├── inventory/schema.py                                  # generic-peer test schema
+    └── processor/
+        ├── test_fetch_and_process_integration.py            # PR gate: correctness + gross-regression counter
+        └── test_fetch_roundtrip_measurement.py              # scheduled: per-shape measured budgets
+```
+
+**Structure Decision**: No new structure. The feature extracted two focused, SDK-free modules (`projection.py`, `peers.py`) out of `infrahub_utils.py` — both are pure enough to unit-test without a client, which is why the projection and batching rules have direct tests rather than only end-to-end ones. Everything else edits files that already existed.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| Principle IV: reads of `self.client.client.store` and `self.client.client.pagination_size` reach past `InfrahubclientWrapper` to the raw SDK client (7 sites; 4 already existed on `develop`, 3 added here) | Peer resolution reads nodes out of the SDK's own `NodeStore` — that store is where `prefetch_relationships` deposits peers, and there is no wrapper-level view of it. Chunking peer ids correctly requires knowing the client's `pagination_size` | Mirroring the store behind the wrapper would mean maintaining a second copy of state the SDK already owns, and would drift the moment the SDK changes how peers land. Passing a hardcoded page size would silently break for anyone who configures a different one |
+| FR-020 requires a query count the wrapper cannot see | The SDK paginates *inside* `client.filters()`, below the wrapper, so no wrapper-level counter can report true round-trips | Reporting only wrapper-level fetch operations would under-report by exactly the amount that matters (pages). See `research.md` for the resolution |

--- a/specs/001-inventory-fetch-performance/quickstart.md
+++ b/specs/001-inventory-fetch-performance/quickstart.md
@@ -22,7 +22,7 @@ Integration tests need Docker and the `integration` dependency group.
 uv sync --group integration
 export INFRAHUB_TESTING_IMAGE_VER=1.9.9
 
-# PR gate: correctness plus a gross-regression counter
+# nightly and on dispatch: correctness plus a gross-regression counter
 uv run --group integration pytest tests/integration/processor -m integration
 
 # Scheduled only: per-shape measured budgets, prints its own totals
@@ -67,8 +67,9 @@ Output was byte-identical to the previous behaviour in all four.
 - **Deleting the per-node refetch.** It looks like dead code. It fired 653 times on a 652-device estate
   and was the only thing resolving attributes through generic peers. See `research.md` R4.
 
-## Where the work is not done
+## Where the last requirement landed
 
-FR-020 / SC-009 — a run reporting its own cost at raised verbosity — is specified but not implemented.
-`research.md` R1 has the design: a counting `Recorder` passed as `Config.custom_recorder` from
-`InfrahubclientWrapper`.
+FR-020 / SC-009 — a run reporting its own cost at raised verbosity — ships in PR #381, built to the
+design in `research.md` R1: a counting `Recorder` passed as `Config.custom_recorder` from
+`InfrahubclientWrapper`. `fetch_and_process` emits the totals at `-v` and the by-kind breakdown behind
+them at `-vvv`.

--- a/specs/001-inventory-fetch-performance/quickstart.md
+++ b/specs/001-inventory-fetch-performance/quickstart.md
@@ -1,0 +1,74 @@
+# Quickstart: Verifying Dynamic Inventory Fetch Performance
+
+How to reproduce the claims in the spec, and what to run before touching this code.
+
+## Verify correctness
+
+```bash
+invoke format && invoke lint          # ruff check + ruff format + yamllint
+uv run mypy .                         # NOT part of `invoke lint` -- run it explicitly
+invoke tests-sanity                   # ansible-test sanity, Docker
+invoke tests-unit                     # 106 unit tests
+```
+
+`invoke lint` does not run mypy, and a failing `ruff check` masks the steps after it. Both have bitten
+this feature; run mypy separately.
+
+## Verify the round-trip budgets
+
+Integration tests need Docker and the `integration` dependency group.
+
+```bash
+uv sync --group integration
+export INFRAHUB_TESTING_IMAGE_VER=1.9.9
+
+# PR gate: correctness plus a gross-regression counter
+uv run --group integration pytest tests/integration/processor -m integration
+
+# Scheduled only: per-shape measured budgets, prints its own totals
+uv run --no-default-groups --group integration pytest \
+  tests/integration/processor/test_fetch_roundtrip_measurement.py \
+  -m integration -p no:pytest-infrahub-performance-test -s -v
+```
+
+The measurement budgets are **measured, not derived**. They depend on SDK pagination behaviour the
+collection does not control, so an `infrahub-sdk` or Infrahub image bump can legitimately shift one by
+±1 with no change under `plugins/`. If one fails after a dependency bump and nothing in `plugins/`
+changed, re-measure with `-s` and move the number, recording the versions. A rise *with* `plugins/`
+changes is a regression.
+
+## Reproduce the headline numbers
+
+Against a real estate (the reported numbers came from ~652 devices):
+
+```bash
+export INFRAHUB_ADDRESS=https://your-instance
+export INFRAHUB_API_TOKEN=<token>
+time ansible-inventory -i your.infrahub.yml --list > /dev/null
+```
+
+To A/B against the previous behaviour, use `git worktree`, not `git stash` — `uv run` re-dirties
+`uv.lock`, which blocks stash pops and can silently block a `git checkout`, leaving you measuring the
+branch you thought you had left.
+
+| Shape | Before | After |
+|---|---|---|
+| Default, no `include` | 700 requests / 3758 KB / 102.71s | 15 / 1555 KB / 3.23s |
+| Narrow `include` | 146 requests / 1673 KB / 22.08s | 18 requests |
+| Two node types (1508 hosts) | 381 requests / 3027 KB / 50.72s | 37 requests |
+| Nested depth-2 | 144 requests / 1648 KB / 20.72s | 18 requests |
+
+Output was byte-identical to the previous behaviour in all four.
+
+## Things that look like improvements and are not
+
+- **Raising `pagination_size`.** 50 → 500 cut requests 20 → 4 and moved wall-clock 7.10s → 7.60s.
+  Recorded in the spec's Out of Scope.
+- **Deleting the per-node refetch.** It looks like dead code. It fired 653 times on a 652-device estate
+  and was the only thing resolving attributes through generic peers. See `research.md` R4.
+
+## Where the work is not done
+
+FR-020 / SC-009 — a run reporting its own cost at raised verbosity — is specified but not implemented.
+`research.md` R1 has the design: a counting `Recorder` passed as `Config.custom_recorder` from
+`InfrahubclientWrapper`.

--- a/specs/001-inventory-fetch-performance/research.md
+++ b/specs/001-inventory-fetch-performance/research.md
@@ -1,0 +1,113 @@
+# Phase 0 Research: Dynamic Inventory Fetch Performance
+
+Only one item in this feature carried an unresolved design question. The other nineteen requirements
+describe delivered code whose decisions were made against measurements rather than research; those are
+recorded here too, briefly, because the measurements are the reason the obvious alternatives were
+rejected and re-proposing them later would waste a cycle.
+
+## R1 — How a run counts the queries it sent (FR-020, SC-009)
+
+**Question**: FR-020 requires a run to report how many queries it sent to Infrahub. The wrapper cannot
+see that number: the SDK paginates inside `client.filters()`, one level below `InfrahubclientWrapper`,
+so a wrapper-level counter reports fetch *operations* and misses exactly the thing that varies — pages.
+
+**Decision**: Implement a counting recorder and pass it as `custom_recorder` when the wrapper builds its
+`Config`.
+
+The SDK exposes a first-class, runtime-checkable `Recorder` protocol — a single method
+`record(response: httpx.Response) -> None` — invoked from `InfrahubClientSync._record` on every HTTP
+response (`infrahub_sdk/client.py:235`, called at four request sites including the sync `_request` at
+`:3788`). `Config` already accepts `custom_recorder`, and the wrapper already constructs `Config` at two
+sites (`infrahub_utils.py:119` and `:126`), so the wiring is a keyword argument in code the wrapper
+already owns.
+
+**Rationale**:
+
+- It counts at the true HTTP boundary, below pagination, so the number reported is the number a network
+  trace would show. That is the number the field reports need.
+- It is a supported extension point, not a monkeypatch. Nothing is reassigned on the client at runtime.
+- It keeps Principle IV intact: the wrapper stays the single place that constructs and configures the
+  SDK client.
+- The counter itself needs no SDK import at runtime — only an annotation, which goes under
+  `TYPE_CHECKING`, exactly as `peers.py` already does for `Callable`. The `HAS_INFRAHUBCLIENT` guard is
+  unaffected.
+
+**Alternatives considered**:
+
+- *Wrap `client.execute_graphql` at runtime, as the tests do.* Accurate, and already proven in
+  `count_graphql` in the integration tests — but reassigning an attribute on the SDK client in
+  production code is a monkeypatch in a place where a supported hook exists. Fine for a test harness,
+  wrong for shipped code.
+- *Count wrapper-level fetch operations only.* Needs no SDK cooperation at all, but under-reports by
+  precisely the amount that matters. A run that sent 15 requests would report 3.
+- *`Config.echo_graphql_queries`.* The SDK can print every query it sends. That is a debugging firehose
+  on stdout, not a count, and it cannot be gated behind Ansible's verbosity.
+
+**Sub-question resolved during implementation (T033)**: the count is reported **once per run**, not per
+node type.
+
+This turned out to be settled by fact rather than preference. The recorder is handed an
+`httpx.Response` and nothing else — there is no node type to attribute a response to at that layer, and
+the SDK does not carry one through. Per-type attribution would need a second, different mechanism
+sitting above the wrapper, which would then be counting fetch operations again and miss pagination —
+the exact failure mode this decision existed to avoid.
+
+What the processor *does* know is attributed and reported alongside: how many related nodes were loaded
+and how many batches it took. So the emitted line is one total request count plus two figures the
+inventory code owns:
+
+```text
+Inventory fetch cost: 15 request(s) to Infrahub, 41 related node(s) loaded in 2 batch(es)
+```
+
+**Consequence worth stating**: the request count covers *every* HTTP round-trip, schema lookups
+included. Those are REST calls, not GraphQL queries, so this figure is legitimately higher than what the
+tests' `count_graphql` helper reports. The integration test asserts `reported >= graphql_calls` rather
+than equality for exactly this reason.
+
+## R2 — Why the peer fetch is batched by id rather than prefetched by type
+
+**Decision**: Fetch related nodes with a filter on the ids actually referenced, chunked by page size.
+
+**Rationale**: The original design fetched a whole related type at once on the reasoning — correct in
+2023 — that one large call beats several small ones. That holds only while the type is small. It makes
+cost track the size of the database rather than the size of the inventory, which is precisely the
+reported failure. Batching by referenced id keeps the "one call per type" shape but bounds what the call
+returns.
+
+**Alternatives considered**: raising `pagination_size` so fewer, larger pages are needed. Measured:
+50 → 500 cut the request count from 20 to 4 but moved wall-clock the wrong way, 7.10s → 7.60s. Rejected,
+and recorded in the spec's Out of Scope so it is not re-proposed.
+
+## R3 — Why chunks are one id short of a page
+
+**Decision**: Chunk peer ids at `pagination_size - 1`.
+
+**Rationale**: The SDK's non-parallel pager stops only once `count - (offset + pagination_size)` goes
+negative. A chunk of exactly `pagination_size` therefore costs a second, empty round-trip. One id short
+avoids it. This is SDK behaviour the collection does not control, which is why the integration budgets
+are documented as measured-against-a-version rather than derived.
+
+## R4 — Why the per-node refetch could not simply be deleted
+
+**Decision**: Replace it with a bounded refill pass rather than remove it.
+
+**Rationale**: The refetch looked like dead code and was assumed to be. It was not: on a 652-device
+estate it fired 653 times. It was the only mechanism making an attribute resolve when a relationship
+declares a *generic* peer — the SDK builds a relationship's inline payload from the **declared** peer
+schema, so an attribute that exists only on the concrete type is never requested and never arrives.
+Deleting it would have made those attributes silently empty. The replacement records what was missing
+during resolution, loads it in one batched pass, then resolves again.
+
+**Alternatives considered**: asking the SDK to project the concrete peer schema. Rejected for this
+feature — it is an SDK change, not a collection change, and the user explicitly declined to open it.
+
+## R5 — Why `include` had to be translated rather than passed through
+
+**Decision**: Convert the user's `include` list into the `exclude` complement the SDK honours.
+
+**Rationale**: Verified by rendering the query both ways: with and without `include`, the SDK produced
+byte-identical 1576-character queries. `include` does not narrow anything — it only opts
+cardinality-many relationships in. Only `exclude` narrows. So a user writing `include: [name]` was
+paying for every attribute on the type. The projection computes the complement of what was asked for and
+passes that as `exclude`.

--- a/specs/001-inventory-fetch-performance/research.md
+++ b/specs/001-inventory-fetch-performance/research.md
@@ -18,7 +18,7 @@ The SDK exposes a first-class, runtime-checkable `Recorder` protocol — a singl
 `record(response: httpx.Response) -> None` — invoked from `InfrahubClientSync._record` on every HTTP
 response (`infrahub_sdk/client.py:235`, called at four request sites including the sync `_request` at
 `:3788`). `Config` already accepts `custom_recorder`, and the wrapper already constructs `Config` at two
-sites (`infrahub_utils.py:119` and `:126`), so the wiring is a keyword argument in code the wrapper
+sites (`infrahub_utils.py:125` and `:136`), so the wiring is a keyword argument in code the wrapper
 already owns.
 
 **Rationale**:
@@ -57,7 +57,7 @@ and how many batches it took. So the emitted line is one total request count plu
 inventory code owns:
 
 ```text
-Inventory fetch cost: 15 request(s) to Infrahub, 41 related node(s) loaded in 2 batch(es)
+Inventory fetch cost: 15 request(s) to Infrahub, 41 node(s) loaded in 2 batch(es)
 ```
 
 **Consequence worth stating**: the request count covers *every* HTTP round-trip, schema lookups

--- a/specs/001-inventory-fetch-performance/spec.md
+++ b/specs/001-inventory-fetch-performance/spec.md
@@ -164,7 +164,7 @@ invalid types. The first must return the valid hosts; the second must raise, nam
 - **FR-017**: The default request timeout MUST be at least 60 seconds, so that a large estate under load is served rather than aborted mid-run.
 - **FR-018**: For any given definition, the hosts and host variables produced MUST be identical to those produced before these changes.
 - **FR-019**: When related nodes of a given type fail to load, the run MUST emit a warning naming that type, MUST still produce every host that referenced them with the affected attributes left empty, and MUST NOT fail on that account.
-- **FR-020**: At raised verbosity, a run MUST report how many requests it sent to Infrahub and how many related nodes it loaded. At default verbosity it MUST report neither. The request figure counts every HTTP round-trip, schema lookups included, so it is legitimately higher than a GraphQL-only count.
+- **FR-020**: At raised verbosity, a run that fetched from Infrahub MUST report how many requests it sent, how many nodes it loaded beyond the hosts themselves, and how many batches that took. At default verbosity it MUST report none of them. A run served entirely from cache sends nothing and so reports nothing. The request figure counts every HTTP round-trip, schema lookups included, so it is legitimately higher than a GraphQL-only count.
 
 ### Key Entities
 
@@ -187,7 +187,7 @@ invalid types. The first must return the valid hosts; the second must raise, nam
 - **SC-006**: Every requested attribute that has a value in Infrahub is present in the produced inventory, including attributes reached through a relationship declared in terms of a broader type.
 - **SC-007**: A run in which every selected node type fails reports an error naming each failure, and never returns an empty inventory silently.
 - **SC-008**: Two runs that differ only in branch, or only in the node types selected, never serve each other's cached results.
-- **SC-009**: A slowness report from the field can be quantified from a raised-verbosity run alone, without attaching an instrumented harness: the run states its own query count and how many related nodes it loaded.
+- **SC-009**: A slowness report from the field can be quantified from a raised-verbosity run alone, without attaching an instrumented harness: the run states its own request count and how many nodes it loaded beyond the hosts themselves.
 
 ## Out of Scope
 

--- a/specs/001-inventory-fetch-performance/spec.md
+++ b/specs/001-inventory-fetch-performance/spec.md
@@ -1,0 +1,210 @@
+# Feature Specification: Dynamic Inventory Fetch Performance
+
+**Feature Branch**: `001-inventory-fetch-performance`
+
+**Created**: 2026-08-23
+
+**Status**: Draft (retroactive — every requirement below describes delivered, verified work)
+
+**Input**: User description: "those performances improvements"
+
+## Clarifications
+
+### Session 2026-08-23
+
+- Q: When a related node that a host references fails to load, what happens to that host? → A: The host is still produced with the affected attribute empty, a warning names the related type that failed, and the run succeeds.
+- Q: Does a run report what it cost, so the next slowness report arrives with a number? → A: Yes, at raised verbosity only — a run states how many queries it sent and how many related nodes it loaded; silent at default verbosity.
+- Q: How far do the performance criteria have to hold — is there a stated host-count ceiling? → A: No ceiling. The guarantee is the shape (FR-001, SC-004); wall-clock claims stay scoped to the measured estate, because elapsed time depends on the related nodes requested and on the health of the Infrahub instance, not on host count alone.
+- Q: Which vocabulary is canonical for the thing a definition selects? → A: The inventory definition's own — **node**, **node type**, **related node** — with **host** reserved for the Ansible inventory entry. Revisit if reserved-variable-name warnings force a renaming.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A large estate builds in seconds, not minutes (Priority: P1)
+
+An automation engineer runs a playbook against an Infrahub instance holding several hundred hosts.
+Their inventory definition asks for a handful of attributes on each host plus a few attributes that
+live on related nodes (a site name, an address, an owner). Today they wait long enough that the
+inventory step dominates the playbook run, and long enough that it sometimes times out. They want the
+inventory to be ready in seconds, and they want exactly the same hosts and variables they got before.
+
+**Why this priority**: This is the reported problem. Everything else in this specification is either a
+prerequisite for it or a correctness guarantee that stops it from being bought with wrong data. A fast
+inventory that returns different variables is a regression, not an improvement.
+
+**Independent Test**: Point the inventory at an estate of several hundred hosts, using a definition
+that reaches into related nodes. Measure wall-clock time and count the queries sent to Infrahub.
+Compare the produced inventory against the previous behaviour for the same definition — it must match
+exactly.
+
+**Acceptance Scenarios**:
+
+1. **Given** an estate of roughly 650 hosts and a definition that requests attributes on related nodes, **When** the inventory is built, **Then** it completes in under 10 seconds and returns the same hosts and host variables as the previous behaviour.
+2. **Given** the same estate, **When** the inventory is built, **Then** the number of queries sent to Infrahub is a small constant, not proportional to the number of hosts.
+3. **Given** an estate twice the size, **When** the inventory is built, **Then** the query count grows with the number of pages of data, not with the number of hosts.
+
+---
+
+### User Story 2 - Asking for less costs less (Priority: P2)
+
+An engineer only needs two attributes per host. They say so in their inventory definition. They expect
+the system to ask Infrahub for those two attributes and nothing else, so the run is cheaper for them
+and lighter on the server they share with everyone else.
+
+**Why this priority**: Independent of P1 and separately valuable — it reduces load on the Infrahub
+instance itself, not just the client's wait. It is second because an estate that is slow with a narrow
+definition is still slow with a wide one; P1 has to hold regardless of what was requested.
+
+**Independent Test**: Build the same inventory twice, once with a narrow attribute selection and once
+with none, and compare the amount of data transferred. The narrow run must transfer measurably less.
+
+**Acceptance Scenarios**:
+
+1. **Given** a definition naming a small set of attributes, **When** the inventory is built, **Then** only those attributes (plus the identifiers every host needs) are requested from Infrahub.
+2. **Given** a definition naming no attributes at all, **When** the inventory is built, **Then** the full previous set of attributes is still returned, unchanged.
+3. **Given** a definition that asks only for the identifier of a related node, **When** the inventory is built, **Then** that related node is never fetched.
+
+---
+
+### User Story 3 - Attributes on related nodes always arrive (Priority: P3)
+
+An engineer's hosts point at a site, and the relationship is declared in terms of a broad, shared type
+("a location") while the attribute they want lives on the specific type ("a site's name"). They expect
+to get the site name. Today they do — but only because the system quietly re-asks for every host that
+looked incomplete, which is the single largest source of the slowness in P1.
+
+**Why this priority**: This is the shape that makes P1 hard. It is listed separately because it is the
+correctness guarantee that must survive the optimisation: if the expensive re-asking is removed without
+replacing it, these values silently become empty. It is the most common relationship shape in real
+schemas.
+
+**Independent Test**: Model a relationship whose declared type does not expose the attribute being
+requested, then request that attribute. It must resolve to the real value, and the run must stay within
+its query budget.
+
+**Acceptance Scenarios**:
+
+1. **Given** a relationship declared through a broad type and an attribute that exists only on the specific type, **When** the inventory is built, **Then** the attribute resolves to its real value.
+2. **Given** that same definition, **When** the inventory is built, **Then** it costs a bounded number of queries rather than one per related node.
+3. **Given** an attribute whose real value is genuinely empty, **When** the inventory is built, **Then** the empty value is accepted as the answer and no further query is made for that host.
+
+---
+
+### User Story 4 - Cached inventories do not collide (Priority: P4)
+
+An engineer works across two branches of their data, and keeps two inventory definitions pointed at the
+same Infrahub instance — one selecting devices, one selecting addresses. With caching enabled, each
+combination must have its own cache entry. Today they can see one definition's results served to the
+other.
+
+**Why this priority**: A correctness bug that only bites users who have enabled caching, and produces
+confusing rather than catastrophic results. Real, but narrower in blast radius than P1-P3.
+
+**Independent Test**: Build cache identities for definitions that differ only by branch, and only by
+selected node types, and confirm all of them differ.
+
+**Acceptance Scenarios**:
+
+1. **Given** two definitions identical except for the branch, **When** both are cached, **Then** they occupy separate cache entries.
+2. **Given** two definitions identical except for the node types selected, **When** both are cached, **Then** they occupy separate cache entries.
+3. **Given** a run served entirely from cache, **When** it completes, **Then** it does not rewrite the cache entry it just read.
+4. **Given** a cache written by an older version whose stored shape differs, **When** a newer version runs, **Then** the stale entry is not reused.
+
+---
+
+### User Story 5 - A failed fetch says so (Priority: P5)
+
+An engineer mistypes a node type, or points at a branch where it does not exist. If some node types
+still resolve, they want the rest of the inventory. If nothing resolves because everything failed, they
+want to be told why — not handed an empty inventory that looks like a legitimately empty estate.
+
+**Why this priority**: Diagnosability rather than performance, but it shares the same code path and the
+same failure surface, and silent-empty is the failure mode most likely to waste an engineer's afternoon.
+
+**Independent Test**: Run one definition with a valid type and an invalid one, and another with only
+invalid types. The first must return the valid hosts; the second must raise, naming what failed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a definition naming one valid and one unknown node type, **When** the inventory is built, **Then** the unknown type is skipped and the valid one still resolves.
+2. **Given** a definition where every named type fails, **When** the inventory is built, **Then** the run fails with a message naming each type and the reason it failed.
+3. **Given** a definition where every named type is valid but genuinely holds no nodes, **When** the inventory is built, **Then** the run succeeds with no hosts and no error.
+4. **Given** a run in which a batch of related nodes fails to load, **When** the inventory is built, **Then** a warning names the related type that failed, every host that referenced it is still produced with the affected attributes empty, and the run succeeds.
+
+### Edge Cases
+
+- An attribute whose real value is `false`, `0`, or an empty string is a present value, not a missing one, and must not be treated as a reason to ask again.
+- More related nodes are referenced than fit in a single page of results — the batch must be split, and every page must be retrieved.
+- A batch of related nodes comes back partially, or fails outright: only the nodes that actually arrived may be treated as retrieved, and hosts referencing the ones that did not arrive are still produced with those attributes left empty.
+- Two different node types are selected in one definition, each with its own attribute selection.
+- An attribute is requested two levels deep (a host's related node's own related node).
+- The same related node is referenced by many hosts — it must be fetched once, not once per referring host.
+- A node type named in the definition does not exist on the selected branch.
+- The Infrahub instance is slow enough under load that a short client timeout aborts an otherwise-successful run.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The number of queries a single inventory run sends to Infrahub MUST be determined by the number of node types selected, the number of pages of results, and the number of distinct related-node types referenced — and MUST NOT grow with the number of hosts.
+- **FR-002**: An attribute that resolves to an empty or absent value MUST NOT cause the system to re-request the host that owns it.
+- **FR-003**: When a definition names the attributes it wants, the system MUST request only those attributes from Infrahub, together with the identifiers every host requires.
+- **FR-004**: When a definition names no attributes, the system MUST return the same full set of attributes it returned previously.
+- **FR-005**: Related nodes MUST be retrieved in batches, grouped by type, containing only the nodes actually referenced by the hosts in this run.
+- **FR-006**: A batch of related nodes MUST be split so that no single request asks for more nodes than one page of results can return, and every resulting page MUST be retrieved.
+- **FR-007**: A related node whose requested attributes are already available MUST NOT be retrieved again.
+- **FR-008**: A related node that has already been retrieved in this run MUST NOT be retrieved again, and only nodes that actually came back may be recorded as retrieved.
+- **FR-009**: An attribute of a related node MUST resolve to its real value even when the relationship is declared in terms of a broader type that does not expose that attribute.
+- **FR-010**: When a definition requests only the identifier of a related node, the system MUST NOT retrieve that node.
+- **FR-011**: Cache entries MUST be distinguished by the Infrahub address, the branch, and the set of node types and attributes requested.
+- **FR-012**: Cache entries MUST carry a version of the stored shape, and entries written under an earlier version MUST NOT be reused.
+- **FR-013**: The cache MUST be written only when the run actually fetched from Infrahub.
+- **FR-014**: A node type that cannot be found MUST be skipped, and the remaining node types MUST still resolve.
+- **FR-015**: When a run retrieves no hosts at all and at least one node type failed, the run MUST fail with a message naming each failed type and its reason.
+- **FR-016**: When a run retrieves no hosts and no node type failed, the run MUST succeed and produce no hosts.
+- **FR-017**: The default request timeout MUST be at least 60 seconds, so that a large estate under load is served rather than aborted mid-run.
+- **FR-018**: For any given definition, the hosts and host variables produced MUST be identical to those produced before these changes.
+- **FR-019**: When related nodes of a given type fail to load, the run MUST emit a warning naming that type, MUST still produce every host that referenced them with the affected attributes left empty, and MUST NOT fail on that account.
+- **FR-020**: At raised verbosity, a run MUST report how many requests it sent to Infrahub and how many related nodes it loaded. At default verbosity it MUST report neither. The request figure counts every HTTP round-trip, schema lookups included, so it is legitimately higher than a GraphQL-only count.
+
+### Key Entities
+
+- **Node**: An entry in Infrahub — a device, an address, a site. Carries attributes and relationships to other nodes. This is the Infrahub sense of the word, not Ansible's: a node becomes a host only if a definition selects its node type.
+- **Host**: An entry in the inventory Ansible acts on, built from one node. The spec keeps *host* and *node* distinct throughout: hosts are what Ansible sees, nodes are what is fetched.
+- **Node type**: The named type of node a definition selects (devices, addresses, sites). Written as a key under `nodes:` in the inventory definition; Infrahub itself calls this a *kind*. One definition may select several, each with its own attribute selection.
+- **Attribute selection**: The list of attributes a definition asks for, which may reach through relationships (a host's site's name). Determines both what is returned and what may be requested.
+- **Related node**: A node referenced by another node through a relationship, whose attributes may be needed to build a host's variables. May be referenced by many hosts.
+- **Cache entry**: A stored inventory result, identified by the address, branch, selection, and stored shape it was built from.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Building an inventory of roughly 650 hosts with attributes reached through relationships completes in under 10 seconds, down from over 100 seconds.
+- **SC-002**: That same run sends at least 95% fewer queries to Infrahub than it did before.
+- **SC-003**: That same run transfers at least 50% less data than it did before.
+- **SC-004**: Doubling the number of hosts in a run does not double the number of queries sent to Infrahub.
+- **SC-005**: For a representative set of definitions — no attribute selection, a narrow selection, several node types, and a two-level selection — the inventory produced is identical to the inventory produced before these changes.
+- **SC-006**: Every requested attribute that has a value in Infrahub is present in the produced inventory, including attributes reached through a relationship declared in terms of a broader type.
+- **SC-007**: A run in which every selected node type fails reports an error naming each failure, and never returns an empty inventory silently.
+- **SC-008**: Two runs that differ only in branch, or only in the node types selected, never serve each other's cached results.
+- **SC-009**: A slowness report from the field can be quantified from a raised-verbosity run alone, without attaching an instrumented harness: the run states its own query count and how many related nodes it loaded.
+
+## Out of Scope
+
+- Exposing or tuning the page size and concurrency settings used when talking to Infrahub. These were measured and did not help: raising the page size cut the query count but did not reduce wall-clock time. They remain at their defaults.
+- Any change to Infrahub itself, or to how it answers queries.
+- Any change to the lookup plugin or to the modules that create and update nodes.
+- Any new user-facing configuration option. The improvement must apply to existing inventory definitions with no edits.
+- Concurrent or asynchronous fetching within a single run.
+
+## Assumptions
+
+- "Slowness" as reported means the wall-clock time to build an inventory, and the load that building it places on the shared Infrahub instance. Both are treated as in scope.
+- The measurements quoted in Success Criteria come from a production-shaped instance of roughly 650 hosts, using definitions that reach attributes through relationships — the shape the reports came from.
+- Existing inventory definitions must keep working unchanged. Identical output is a hard requirement, not a goal; a faster run that returns different variables is a regression.
+- Users may or may not have caching enabled. The cache correctness requirements apply only when they do, and no behaviour change is expected for users who do not.
+- The Infrahub instance being queried supports retrieving several nodes of one type by identifier in a single request. Without that, batching related nodes is not possible.
+- Raising the default timeout is a safety net for large estates, not a performance measure; runs are expected to finish well inside it.
+- Wall-clock time is not a function of host count alone. It also depends on how many related nodes a definition reaches into, how many distinct types those span, and the health and load of the Infrahub instance answering. The measured figures in SC-001 to SC-003 therefore describe one real estate rather than a promise that scales; SC-004 and FR-001 carry the part that generalises.
+- No maximum estate size is specified. A definition that stays within the cost shape of FR-001 is expected to keep working as the estate grows, but no wall-clock figure is claimed beyond what was measured.
+- Attribute names reaching the inventory as host variables can collide with names Ansible reserves, which produces a warning at run time. That is a pre-existing condition of the plugin, untouched by this work and out of scope here, but it is the one thing likely to force the naming settled above to be revisited.

--- a/specs/001-inventory-fetch-performance/tasks.md
+++ b/specs/001-inventory-fetch-performance/tasks.md
@@ -22,10 +22,10 @@ description: "Task list for Dynamic Inventory Fetch Performance"
 
 ## Delivery status
 
-This is a retroactive task list. 19 of the spec's 20 functional requirements describe code that is
-implemented, measured, and passing CI. Phases 1–7 record that work so coverage is traceable rather than
-assumed. **Phase 8 is the only outstanding implementation work** — FR-020 / SC-009, added during
-`/speckit.clarify`.
+This is a retroactive task list. **All 20 of the spec's functional requirements are implemented and
+passing CI.** Phases 1–7 shipped in PR #374; Phase 8 — FR-020 / SC-009, added during
+`/speckit.clarify` — ships in PR #381. Phases 1–7 record the earlier work so coverage is traceable
+rather than assumed. What remains unchecked is Phase 9 repo hygiene, which gates nothing.
 
 Read `- [X]` as "requirement covered and verified", not as "task someone should do".
 
@@ -242,11 +242,10 @@ T041 → T042                               # docs, then spec status
 
 ## Implementation Strategy
 
-**Everything through Phase 7 is delivered.** The MVP shipped; PR #374 carries it at 22/22 checks green.
+**Everything through Phase 8 is delivered.** Phases 1–7 shipped in PR #374 at 22/22 checks green.
 
-The remaining decision is where Phase 8 lands:
+Phase 8 was taken as the follow-up rather than folded back into #374 — 10 tasks across one new module
+plus three edits to `infrahub_utils.py`, a small independently testable increment that left a green,
+byte-identical-verified diff closed. It ships in PR #381, at which point the spec is fully retroactive.
 
-- **Fold into PR #374** — the spec becomes fully retroactive in one merge, but reopens a diff that is green and byte-identical-verified for a feature that has not been measured
-- **Ship #374, take Phase 8 as a follow-up** — recommended. Phase 8 is 10 tasks touching one new module plus three edits to `infrahub_utils.py`; it is a clean, small, independently testable increment
-
-Phase 9 is repo hygiene and should not gate either.
+Phase 9 is repo hygiene and gates nothing.

--- a/specs/001-inventory-fetch-performance/tasks.md
+++ b/specs/001-inventory-fetch-performance/tasks.md
@@ -1,0 +1,252 @@
+---
+
+description: "Task list for Dynamic Inventory Fetch Performance"
+---
+
+# Tasks: Dynamic Inventory Fetch Performance
+
+**Input**: Design documents from `/specs/001-inventory-fetch-performance/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Test tasks ARE included. This feature's central risk is a fast-but-wrong inventory, and the spec makes identical output a hard requirement (FR-018), so every story carries the test that proves it.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and verified independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1–US5)
+- `- [X]` marks a task **already delivered** in PR #374, verified and green
+- `- [ ]` marks **forward work**
+
+## Delivery status
+
+This is a retroactive task list. 19 of the spec's 20 functional requirements describe code that is
+implemented, measured, and passing CI. Phases 1–7 record that work so coverage is traceable rather than
+assumed. **Phase 8 is the only outstanding implementation work** — FR-020 / SC-009, added during
+`/speckit.clarify`.
+
+Read `- [X]` as "requirement covered and verified", not as "task someone should do".
+
+## Path Conventions
+
+Ansible collection layout: plugins under `plugins/`, tests under `tests/unit/` and `tests/integration/`.
+Paths below are repository-relative, per plan.md.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Carve the two SDK-free modules out of `infrahub_utils.py` so projection and batching rules are unit-testable without a client
+
+- [X] T001 Create `plugins/module_utils/projection.py` with collection boilerplate (Opsmill copyright, GPLv3 reference, `from __future__` imports, `__metaclass__ = type`)
+- [X] T002 [P] Create `plugins/module_utils/peers.py` with the same boilerplate, keeping `Callable` under `TYPE_CHECKING` so no SDK import is needed at runtime
+- [X] T003 [P] Register both modules in the Key Files table in `plugins/AGENTS.md` and update the module_utils count
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Changes every story depends on
+
+**⚠️ CRITICAL**: No story work can begin until this phase is complete
+
+- [X] T004 Add a `parallel: bool = True` parameter to `fetch_nodes` in `plugins/module_utils/infrahub_utils.py` so peer batches can opt out of the parallel pager
+- [X] T005 Convert `HostFetch` from a `NamedTuple` to a `@dataclass` in `plugins/module_utils/infrahub_utils.py` (its dict/list fields are mutated in place during the fetch loop)
+- [X] T006 Resolve host schemas with `fetch_single_schema(kind=..., raise_when_missing=False)` in `_fetch_host_nodes` in `plugins/module_utils/infrahub_utils.py`, so an unknown kind is skipped regardless of whether the wrapper's exception decorator is installed
+- [X] T007 [P] Raise the `timeout` default from 10 to 60 in the `DOCUMENTATION` block of `plugins/inventory/inventory.py`, then run `invoke generate-doc` (FR-017; constitution Principle V)
+- [X] T008 Delete the now-unreachable `get_related_nodes` from `plugins/module_utils/infrahub_utils.py`
+
+**Checkpoint**: Foundation ready — story work can proceed
+
+---
+
+## Phase 3: User Story 1 - A large estate builds in seconds, not minutes (Priority: P1) 🎯 MVP
+
+**Goal**: Make fetch cost track what was asked for rather than database size, with byte-identical output
+
+**Independent Test**: Build an inventory of ~650 hosts with attributes reached through relationships; measure wall-clock and count requests; diff the produced inventory against the previous behaviour
+
+### Tests for User Story 1
+
+- [X] T009 [P] [US1] Rewrite resolution unit tests in `tests/unit/plugins/module_utils/test_fetch_and_process_resolution.py`, stubbing `wrapper.client.store.get` and `wrapper.client.pagination_size`
+- [X] T010 [P] [US1] Add per-shape measured round-trip budgets in `tests/integration/processor/test_fetch_roundtrip_measurement.py`, marked `measurement` so the heavy schema-convergence run stays off the PR gate
+- [X] T011 [P] [US1] Add a gross-regression request counter to `tests/integration/processor/test_fetch_and_process_integration.py`, with the budget derived from `pagination_size` rather than hardcoded
+
+### Implementation for User Story 1
+
+- [X] T012 [US1] Build a per-node-type `NodeProjection` in `_fetch_host_nodes` in `plugins/module_utils/infrahub_utils.py` and carry it on `HostFetch.projections`
+- [X] T013 [US1] Guard the refill on `node_attr.value is None` in `_resolve_schema_attribute` in `plugins/module_utils/infrahub_utils.py`, so `False`, `0`, and `""` count as present values (FR-002)
+- [X] T014 [US1] Orchestrate warm → resolve → refill → resolve in `fetch_and_process` in `plugins/module_utils/infrahub_utils.py`, sharing `warmer.loaded` with the ledger so a fully-fetched peer is never re-queued
+
+**Checkpoint**: Inventory of ~650 hosts builds in 3.23s (was 102.71s) at 15 requests (was 700), output byte-identical
+
+---
+
+## Phase 4: User Story 2 - Asking for less costs less (Priority: P2)
+
+**Goal**: Translate the user's attribute selection into a request the SDK actually narrows
+
+**Independent Test**: Build the same inventory with and without a narrow selection; the narrow run transfers measurably less
+
+### Tests for User Story 2
+
+- [X] T015 [P] [US2] Unit tests for projection build, complement, and `projected()` in `tests/unit/plugins/module_utils/test_projection.py`
+
+### Implementation for User Story 2
+
+- [X] T016 [US2] Implement `NodeProjection.build` in `plugins/module_utils/projection.py`: compute the complement of the selection's roots against the schema and pass it as `exclude`, since `include` alone does not narrow (research.md R5)
+- [X] T017 [P] [US2] Preserve the historical wide query when no selection is given (`narrowed = False`) in `plugins/module_utils/projection.py` (FR-004)
+- [X] T018 [P] [US2] Short-circuit bare relationships in `_resolve_one_relationship` and `_resolve_many_relationship` in `plugins/module_utils/infrahub_utils.py` — return peer ids without fetching peers (FR-010)
+
+**Checkpoint**: Narrow selections transfer less; wide selections unchanged; US1 still passing
+
+---
+
+## Phase 5: User Story 3 - Attributes on related nodes always arrive (Priority: P3)
+
+**Goal**: Resolve attributes through relationships that declare a broad peer type, without one request per peer
+
+**Independent Test**: Model a relationship whose declared peer type omits the requested attribute; the attribute must resolve, within budget
+
+### Tests for User Story 3
+
+- [X] T019 [P] [US3] Unit tests for `PeerWarmer` and `RefillLedger` in `tests/unit/plugins/module_utils/test_peers.py`, with the fake fetch returning a node per requested id and an optional `found` set
+- [X] T020 [P] [US3] Add a generic `TestingLocation` plus concrete `TestingSite` to `tests/integration/inventory/schema.py` so a declared-generic peer can be exercised end to end
+- [X] T021 [P] [US3] Add `test_generic_peer_attribute_resolves_and_stays_bounded` to `tests/integration/processor/test_fetch_roundtrip_measurement.py`
+
+### Implementation for User Story 3
+
+- [X] T022 [US3] Implement `PeerWarmer.collect` in `plugins/module_utils/peers.py`: compute nested roots per **node type** (not per node), and skip peers already satisfied in the store via `_is_satisfied`
+- [X] T023 [US3] Implement `PeerWarmer.warm` in `plugins/module_utils/peers.py`: chunk ids at `pagination_size - 1` (research.md R3), fetch by `{"ids": chunk}` with `parallel=False`, and record only ids present in the response (FR-008)
+- [X] T024 [P] [US3] Make `RefillLedger.record` projection-aware in `plugins/module_utils/peers.py` so an attribute nobody asked for is never queued
+- [X] T025 [US3] Wire `_warm_peers` in `plugins/module_utils/infrahub_utils.py` to collect then warm, with `Order(disable=True)` and no schema fetch for peer kinds
+
+**Checkpoint**: Generic-peer attributes resolve within a bounded request count; the per-node refetch is gone
+
+---
+
+## Phase 6: User Story 4 - Cached inventories do not collide (Priority: P4)
+
+**Goal**: Key each cache entry to the request that produced it
+
+**Independent Test**: Build cache identities for definitions differing only by branch, and only by node selection; all must differ
+
+### Tests for User Story 4
+
+- [X] T026 [P] [US4] Unit tests for cache-key distinctness in `tests/unit/plugins/inventory/test_inventory_cache_key.py`
+
+### Implementation for User Story 4
+
+- [X] T027 [US4] Hash endpoint, branch, node selection, and `CACHE_SCHEMA_VERSION` into `_cache_key` in `plugins/inventory/inventory.py`, annotating the local for mypy (FR-011, FR-012)
+- [X] T028 [US4] Call `_store_in_cache` only when `need_to_load_from_api` in `plugins/inventory/inventory.py` (FR-013)
+
+**Checkpoint**: Two definitions differing only in branch or selection no longer share a cache entry
+
+---
+
+## Phase 7: User Story 5 - A failed fetch says so (Priority: P5)
+
+**Goal**: Skip what fails, report when everything fails, never hand back a silently empty inventory
+
+**Independent Test**: Run one definition with a valid and an invalid node type, and another with only invalid types
+
+### Tests for User Story 5
+
+- [X] T029 [P] [US5] Add `test_unknown_kind_is_skipped_not_fatal` to `tests/integration/processor/test_fetch_and_process_integration.py`, built through `__new__` so the skip cannot come from the exception decorator
+
+### Implementation for User Story 5
+
+- [X] T030 [US5] Record per-type failures in `HostFetch.failures` and warn on an unresolvable schema in `_fetch_host_nodes` in `plugins/module_utils/infrahub_utils.py` (FR-014)
+- [X] T031 [US5] Raise a `RuntimeError` naming every failed type when no nodes were fetched and at least one type failed, in `fetch_and_process` in `plugins/module_utils/infrahub_utils.py` (FR-015); return cleanly when nothing failed (FR-016)
+- [X] T032 [US5] Pass an `on_error` callback into `PeerWarmer` from `fetch_and_process` in `plugins/module_utils/infrahub_utils.py` that warns and continues, leaving hosts produced with the attribute empty (FR-019)
+
+**Checkpoint**: All five stories independently verified; 106 unit tests and 14 integration tests green
+
+---
+
+## Phase 8: Cross-Cutting - Run cost reporting (FR-020, SC-009) ✅ COMPLETE
+
+**Purpose**: Let a run state its own cost at raised verbosity, so the next field report arrives as a number instead of an anecdote. This is the only unimplemented requirement in the spec.
+
+**Design**: research.md R1 — a counting `Recorder` passed as `Config.custom_recorder` from `InfrahubclientWrapper`. Counts at the true HTTP boundary, below the SDK's pagination, using a supported extension point rather than a monkeypatch.
+
+**Independent Test**: Run an inventory at `-v` against a known estate and confirm the reported request count matches an independent count of HTTP responses; run at default verbosity and confirm silence; run fully from cache and confirm nothing is reported.
+
+- [X] T033 Decide whether the count is reported once per run or once per node type, and record the decision in `specs/001-inventory-fetch-performance/research.md` under R1 (research.md flags this as the one open sub-question; per-type aids diagnosis, a single total is what SC-009 literally asks for)
+- [X] T034 [P] Create `plugins/module_utils/metrics.py` with collection boilerplate and a `RequestCounter` implementing the SDK's `Recorder` protocol — a `record(response)` that increments a counter, with the `httpx.Response` annotation under `TYPE_CHECKING` so no SDK import is required at runtime
+- [X] T035 [P] Unit tests for `RequestCounter` in `tests/unit/plugins/module_utils/test_metrics.py`: counts increment per call, start at zero, and the module imports without `infrahub_sdk` installed
+- [X] T036 Pass the counter as `custom_recorder` in both `Config(...)` constructions in `plugins/module_utils/infrahub_utils.py` (around lines 119 and 126) and expose it on `InfrahubclientWrapper`
+- [X] T037 Return the peer-batch count from `_warm_peers` in `plugins/module_utils/infrahub_utils.py` instead of discarding `warmer.warm(...)`'s return value, and total the related nodes loaded
+- [X] T038 Emit the report from `fetch_and_process` in `plugins/module_utils/infrahub_utils.py` via `_handle_display(level="INFO")`, which maps to `display.v()` — raised verbosity only, silent at default (FR-020)
+- [X] T039 [P] Add a unit test in `tests/unit/plugins/module_utils/test_fetch_and_process_resolution.py` asserting the report is emitted at INFO and absent at default verbosity
+- [X] T040 [P] Assert the reported count matches the independently-counted round-trips in `tests/integration/processor/test_fetch_and_process_integration.py`, reusing the existing `count_graphql` helper as the independent reference (SC-009)
+- [X] T041 Document the diagnostics behaviour in `dev/knowledge/inventory-and-lookup.md` and confirm `specs/001-inventory-fetch-performance/contracts/inventory-options.md` no longer marks FR-020 as unimplemented
+- [X] T042 Update the spec's Status line and `checklists/requirements.md` notes in `specs/001-inventory-fetch-performance/` to drop the "FR-020 not yet implemented" caveat
+
+**Checkpoint**: FR-020 and SC-009 satisfied; the spec becomes fully retroactive
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+- [ ] T043 [P] Fix the `HAS_GIT: unbound variable` failure at `.specify/scripts/bash/update-agent-context.sh:147`, and make feature resolution fall back to `.specify/feature.json` rather than requiring a numbered git branch
+- [ ] T044 [P] Trim the run-on "Active Technologies" entry the agent-context script appended to `CLAUDE.md`, or move the generated block inside the `<!-- SPECKIT -->` markers so it stays managed
+- [ ] T045 Reconcile the stale Constraints section of `.specify/memory/constitution.md` (Python `>=3.10,<3.14`, `ansible-core>=2.17.7rc1`, `infrahub-sdk>=1.5,<2.0`) against the real pins in `pyproject.toml`, as an explicit constitution amendment
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)** → no dependencies
+- **Phase 2 (Foundational)** → depends on Phase 1; blocks Phases 3–7
+- **Phase 3 (US1)** → depends on Phase 2
+- **Phases 4–7 (US2–US5)** → depend on Phase 2; independent of each other
+- **Phase 8 (FR-020)** → depends on Phase 2 only. It reads `_warm_peers`' return value, so T037 assumes Phase 5's `_warm_peers` exists — already true
+- **Phase 9 (Polish)** → independent of everything; T043–T045 are repo hygiene, not feature work
+
+### User Story Dependencies
+
+- **US1 (P1)** is the MVP and stands alone
+- **US2, US4, US5** are independent of US1 and of each other
+- **US3** shares `peers.py` with US1's orchestration; US1's checkpoint depends on US3's warming existing, because removing the per-node refetch without it makes generic-peer attributes silently empty (research.md R4). Implement US3's warming before declaring US1 done
+
+### Within Each User Story
+
+Tests → models/pure modules → orchestration in `infrahub_utils.py` → verification.
+
+### Parallel Opportunities
+
+- T001/T002/T003 — three different files
+- T009/T010/T011 — three different test files
+- Phases 4, 6, 7 touch disjoint files and could run concurrently once Phase 2 lands
+- **Phase 8**: T034 and T035 are parallel (new module + its test). T036–T038 are sequential — all three edit `infrahub_utils.py`. T039/T040 are parallel afterwards
+
+## Parallel Example: Phase 8
+
+```text
+T033 (decide reporting granularity)      # blocks nothing but shapes T038
+  ├─ T034 [P] plugins/module_utils/metrics.py
+  └─ T035 [P] tests/unit/plugins/module_utils/test_metrics.py
+        ↓
+T036 → T037 → T038                        # all in infrahub_utils.py, sequential
+        ↓
+  ├─ T039 [P] unit assertion
+  └─ T040 [P] integration assertion
+        ↓
+T041 → T042                               # docs, then spec status
+```
+
+## Implementation Strategy
+
+**Everything through Phase 7 is delivered.** The MVP shipped; PR #374 carries it at 22/22 checks green.
+
+The remaining decision is where Phase 8 lands:
+
+- **Fold into PR #374** — the spec becomes fully retroactive in one merge, but reopens a diff that is green and byte-identical-verified for a feature that has not been measured
+- **Ship #374, take Phase 8 as a follow-up** — recommended. Phase 8 is 10 tasks touching one new module plus three edits to `infrahub_utils.py`; it is a clean, small, independently testable increment
+
+Phase 9 is repo hygiene and should not gate either.

--- a/tests/integration/processor/test_fetch_and_process_integration.py
+++ b/tests/integration/processor/test_fetch_and_process_integration.py
@@ -152,19 +152,19 @@ class TestFetchAndProcessIntegration(TestInfrahubDockerClient):
     ) -> None:
         """FR-020 / SC-009: the run states its own cost, and the number is true.
 
-        Two things are checked, because either alone would pass while lying:
+        Three things are checked, because any one alone would pass while lying:
 
-        * The number printed equals what the SDK-level recorder saw. A report that
-          drifts from the counter is worse than no report.
+        * The number printed equals what the SDK-level recorder saw *for this run*. A
+          report that drifts from the counter is worse than no report.
+        * It is strictly below the client's lifetime total. The client outlives a run,
+          so a report that skipped the snapshot would charge this run for what came
+          before it -- and against a zero baseline that misreads as correct.
         * It is at least the GraphQL round-trip count. It is deliberately *not*
           asserted equal: schema lookups go over REST, so they are counted by the
           recorder and invisible to ``count_graphql``. Asserting equality here would
           encode a wrong idea of what the number means and would break the first time
           a schema fetch moved.
         """
-        for name in ("cost-1", "cost-2"):
-            client_sync.create(kind="BuiltinTag", name=name).save()
-
         counter = RequestCounter()
         original_recorder = client_sync.config.custom_recorder
         client_sync.config.custom_recorder = counter
@@ -173,7 +173,15 @@ class TestFetchAndProcessIntegration(TestInfrahubDockerClient):
         processor.display = _CapturingDisplay()
 
         try:
-            counter.reset()
+            # Spend requests with the counter already attached, so the run starts from
+            # a non-zero baseline. Resetting to zero instead -- as this test used to --
+            # makes the delta and the lifetime total the same number, and the equality
+            # below would survive a regression that dropped the snapshot.
+            for name in ("cost-1", "cost-2"):
+                client_sync.create(kind="BuiltinTag", name=name).save()
+            baseline = counter.responses
+            assert baseline, "the setup requests went uncounted, so the delta below proves nothing"
+
             with count_graphql(client_sync) as trackers:
                 result = processor.fetch_and_process(nodes={"BuiltinTag": {"include": ["name"]}})
         finally:
@@ -189,7 +197,14 @@ class TestFetchAndProcessIntegration(TestInfrahubDockerClient):
         reported = int(match.group(1))
         graphql_calls = sum(trackers.values())
 
-        assert reported == counter.responses, f"reported {reported}, recorder saw {counter.responses}"
+        assert reported == counter.responses - baseline, (
+            f"reported {reported}, recorder saw {counter.responses - baseline} for this run "
+            f"({counter.responses} total, {baseline} before it)"
+        )
+        assert reported < counter.responses, (
+            f"reported {reported} and the client's lifetime total is {counter.responses}: "
+            "the run's cost is not being isolated from requests that preceded it"
+        )
         # -vvv carries the per-kind detail behind that total.
         breakdown = "\n".join(processor.display.very_verbose)
         assert "Inventory fetch cost, by kind:" in breakdown, processor.display.very_verbose

--- a/tests/integration/processor/test_fetch_and_process_integration.py
+++ b/tests/integration/processor/test_fetch_and_process_integration.py
@@ -18,12 +18,14 @@ Run with:  ``uv run --group integration pytest tests/integration/processor -m in
 from __future__ import annotations
 
 import math
+import re
 
 import pytest
 
 # Skip cleanly when the testcontainers stack isn't installed (e.g. default dev env).
 pytest.importorskip("infrahub_testcontainers")
 
+from ansible_collections.opsmill.infrahub.plugins.module_utils.metrics import RequestCounter
 from infrahub_sdk import InfrahubClientSync
 from infrahub_sdk.testing.docker import TestInfrahubDockerClient
 
@@ -41,6 +43,29 @@ def _page_budget(client: InfrahubClientSync, node_count: int) -> int:
     """
     pages = max(1, math.ceil(node_count / client.pagination_size))
     return 1 + pages
+
+
+class _CapturingDisplay:
+    """The parts of Ansible's Display that ``_handle_display`` actually calls."""
+
+    def __init__(self) -> None:
+        self.verbose: list[str] = []
+        self.very_verbose: list[str] = []
+
+    def debug(self, msg: str) -> None:
+        pass
+
+    def v(self, msg: str) -> None:
+        self.verbose.append(msg)
+
+    def vvv(self, msg: str) -> None:
+        self.very_verbose.append(msg)
+
+    def warning(self, msg: str) -> None:
+        pass
+
+    def error(self, msg: str) -> None:
+        pass
 
 
 class TestFetchAndProcessIntegration(TestInfrahubDockerClient):
@@ -121,3 +146,56 @@ class TestFetchAndProcessIntegration(TestInfrahubDockerClient):
         resolved_names = {attrs.get("name") for attrs in result.values()}
         for name in seeded_tags:
             assert name in resolved_names
+
+    def test_reported_request_count_matches_the_counter_and_covers_graphql(
+        self, client_sync: InfrahubClientSync
+    ) -> None:
+        """FR-020 / SC-009: the run states its own cost, and the number is true.
+
+        Two things are checked, because either alone would pass while lying:
+
+        * The number printed equals what the SDK-level recorder saw. A report that
+          drifts from the counter is worse than no report.
+        * It is at least the GraphQL round-trip count. It is deliberately *not*
+          asserted equal: schema lookups go over REST, so they are counted by the
+          recorder and invisible to ``count_graphql``. Asserting equality here would
+          encode a wrong idea of what the number means and would break the first time
+          a schema fetch moved.
+        """
+        for name in ("cost-1", "cost-2"):
+            client_sync.create(kind="BuiltinTag", name=name).save()
+
+        counter = RequestCounter()
+        original_recorder = client_sync.config.custom_recorder
+        client_sync.config.custom_recorder = counter
+        processor = processor_for(client_sync)
+        processor.client.request_counter = counter
+        processor.display = _CapturingDisplay()
+
+        try:
+            counter.reset()
+            with count_graphql(client_sync) as trackers:
+                result = processor.fetch_and_process(nodes={"BuiltinTag": {"include": ["name"]}})
+        finally:
+            # The client is class-scoped and shared with the tests above.
+            client_sync.config.custom_recorder = original_recorder
+
+        assert result
+        cost_lines = [line for line in processor.display.verbose if "Inventory fetch cost" in line]
+        assert len(cost_lines) == 1, processor.display.verbose
+
+        match = re.search(r"(\d+) request\(s\)", cost_lines[0])
+        assert match, f"no request count in the reported line: {cost_lines[0]!r}"
+        reported = int(match.group(1))
+        graphql_calls = sum(trackers.values())
+
+        assert reported == counter.responses, f"reported {reported}, recorder saw {counter.responses}"
+        # -vvv carries the per-kind detail behind that total.
+        breakdown = "\n".join(processor.display.very_verbose)
+        assert "Inventory fetch cost, by kind:" in breakdown, processor.display.very_verbose
+        assert "host kind BuiltinTag:" in breakdown, breakdown
+
+        assert reported >= graphql_calls, (
+            f"reported {reported} requests but {graphql_calls} GraphQL round-trips were made; "
+            "the recorder sits below GraphQL and must see at least as many"
+        )

--- a/tests/unit/plugins/module_utils/test_fetch_and_process_resolution.py
+++ b/tests/unit/plugins/module_utils/test_fetch_and_process_resolution.py
@@ -278,7 +278,7 @@ def test_run_cost_degrades_when_no_counter_is_attached(mocker):
 
     cost_line = next(line for line in _display_lines(processor.display) if "Inventory fetch cost" in line)
     assert "unavailable" in cost_line
-    assert "related node(s) loaded" in cost_line
+    assert "node(s) loaded" in cost_line
 
 
 def test_run_cost_counts_the_peer_batches_it_issued(mocker):
@@ -376,6 +376,66 @@ def test_run_cost_breakdown_is_empty_when_there_is_nothing_to_say():
 
     warmer = PeerWarmer(fetch=lambda **kw: [], store=None)
     assert iu.InfrahubNodesProcessor._run_cost_breakdown(fetched=iu.HostFetch(), warmer=warmer) == []
+
+
+def test_run_cost_breakdown_calls_a_refilled_host_kind_by_its_name():
+    """A host kind reaching the warmer got there through refill, not a relationship.
+
+    Both passes share one warmer, so refill files host kinds into the same stats map.
+    Calling those a peer kind points the reader at the wrong cause.
+    """
+    from ansible_collections.opsmill.infrahub.plugins.module_utils.peers import PeerWarmer
+
+    fetched = iu.HostFetch()
+    fetched.nodes = [FakeNode("KindA", "a1")]
+    warmer = PeerWarmer(fetch=lambda **kw: [], store=None)
+    warmer.stats = {
+        "KindA": {"requested": 1, "batches": 1, "loaded": 1, "failed": 0},
+        "LocationSite": {"requested": 1, "batches": 1, "loaded": 1, "failed": 0},
+    }
+
+    joined = "\n".join(iu.InfrahubNodesProcessor._run_cost_breakdown(fetched=fetched, warmer=warmer))
+
+    assert "refilled host kind KindA:" in joined
+    assert "peer kind LocationSite:" in joined
+    assert "peer kind KindA:" not in joined
+
+
+def test_run_cost_names_failed_batches_in_the_totals(mocker):
+    """A batch that failed still cost a round-trip, so the cost line says so."""
+    shared = FakePeer("site-1", "LocationSite")
+    nodes_by_kind = {"KindA": [FakeNode("KindA", "a1", peer=shared)]}
+    processor, wrapper = _make_processor(mocker, nodes_by_kind, attrs=["name", "site.name"])
+    processor.display = mocker.MagicMock()
+    mocker.patch.object(processor, "resolve_node_mapping", return_value={"id": "x"})
+
+    hosts = wrapper.fetch_nodes.side_effect
+
+    def failing_peer_fetch(kind, **kwargs):
+        if kind == "LocationSite":
+            raise RuntimeError("boom")
+        return hosts(kind, **kwargs)
+
+    wrapper.fetch_nodes.side_effect = failing_peer_fetch
+
+    processor.fetch_and_process(nodes={"KindA": {}})
+
+    cost_line = next(line for line in _display_lines(processor.display) if "Inventory fetch cost" in line)
+    assert "1 batch(es) failed" in cost_line, cost_line
+    # The batch that failed loaded nothing, so it is not folded into the loaded count.
+    assert "0 node(s) loaded in 0 batch(es)" in cost_line, cost_line
+
+
+def test_run_cost_is_reported_when_the_query_matched_no_hosts(mocker):
+    """An empty-but-successful fetch still cost requests, and still reports them."""
+    processor, _wrapper = _make_processor(mocker, {})
+    processor.display = mocker.MagicMock()
+
+    assert processor.fetch_and_process(nodes={"KindA": {}}) is None
+
+    cost_lines = [line for line in _display_lines(processor.display) if "Inventory fetch cost" in line]
+    assert len(cost_lines) == 1, _display_lines(processor.display)
+    assert "0 node(s) loaded in 0 batch(es)" in cost_lines[0]
 
 
 def test_a_swallowed_fetch_is_a_failure_not_an_empty_result(mocker):

--- a/tests/unit/plugins/module_utils/test_fetch_and_process_resolution.py
+++ b/tests/unit/plugins/module_utils/test_fetch_and_process_resolution.py
@@ -201,6 +201,183 @@ def test_a_kind_with_no_schema_alone_raises(mocker):
         processor.fetch_and_process(nodes={"NoSuchKind": {}})
 
 
+def _display_lines(display, level="v"):
+    """The messages emitted at one Display level."""
+    return [c.args[0] if c.args else c.kwargs.get("msg", "") for c in getattr(display, level).call_args_list]
+
+
+def test_run_cost_is_reported_at_raised_verbosity(mocker):
+    """The run states what it cost, through ``Display.v`` and not through plain output.
+
+    ``Display.v`` is what Ansible gates behind ``-v``. Emitting the same line through
+    ``display.display`` or ``error`` would put diagnostics into every playbook's
+    normal output, which is why the level matters more than the wording here.
+    """
+    nodes_by_kind = {"KindA": [FakeNode("KindA", "a1"), FakeNode("KindA", "a2")]}
+    processor, _wrapper = _make_processor(mocker, nodes_by_kind)
+    processor.display = mocker.MagicMock()
+    mocker.patch.object(processor, "resolve_node_mapping", return_value={"id": "x"})
+
+    processor.fetch_and_process(nodes={"KindA": {}})
+
+    cost_lines = [line for line in _display_lines(processor.display) if "Inventory fetch cost" in line]
+    assert len(cost_lines) == 1, _display_lines(processor.display)
+    # Never at default verbosity.
+    assert not [c for c in processor.display.display.call_args_list if "Inventory fetch cost" in str(c)]
+    assert not [c for c in processor.display.error.call_args_list if "Inventory fetch cost" in str(c)]
+
+
+def test_run_cost_reports_this_run_not_the_client_lifetime(mocker):
+    """The figure is a delta, and it comes from the SDK-level counter.
+
+    Two failure modes are covered here. Counting the wrapper's own calls would miss
+    pagination, which happens inside the SDK -- exactly the part that grows with the
+    estate. And reporting the counter's absolute value would charge this run for
+    every request the client made before it, because the counter belongs to the
+    client and outlives a single ``fetch_and_process``.
+    """
+    from ansible_collections.opsmill.infrahub.plugins.module_utils.metrics import RequestCounter
+
+    counter = RequestCounter()
+    for _ in range(5):  # an earlier run on the same client
+        counter.record(response=None)
+
+    nodes_by_kind = {"KindA": [FakeNode("KindA", "a1")]}
+    processor, wrapper = _make_processor(mocker, nodes_by_kind)
+    wrapper.request_counter = counter
+    processor.display = mocker.MagicMock()
+    mocker.patch.object(processor, "resolve_node_mapping", return_value={"id": "x"})
+
+    # Each fetch this run makes costs two round-trips (a count query and a page).
+    inner = wrapper.fetch_nodes.side_effect
+
+    def counting_fetch(kind, **kwargs):
+        counter.record(response=None)
+        counter.record(response=None)
+        return inner(kind, **kwargs)
+
+    wrapper.fetch_nodes.side_effect = counting_fetch
+
+    processor.fetch_and_process(nodes={"KindA": {}})
+
+    cost_line = next(line for line in _display_lines(processor.display) if "Inventory fetch cost" in line)
+    assert "2 request(s)" in cost_line, cost_line
+    # The 5 requests from before this run are not charged to it.
+    assert "7 request(s)" not in cost_line
+    assert counter.responses == 7
+
+
+def test_run_cost_degrades_when_no_counter_is_attached(mocker):
+    """A wrapper without a counter still reports the peer figures, and does not raise."""
+    nodes_by_kind = {"KindA": [FakeNode("KindA", "a1")]}
+    processor, _wrapper = _make_processor(mocker, nodes_by_kind)
+    processor.display = mocker.MagicMock()
+    mocker.patch.object(processor, "resolve_node_mapping", return_value={"id": "x"})
+
+    processor.fetch_and_process(nodes={"KindA": {}})
+
+    cost_line = next(line for line in _display_lines(processor.display) if "Inventory fetch cost" in line)
+    assert "unavailable" in cost_line
+    assert "related node(s) loaded" in cost_line
+
+
+def test_run_cost_counts_the_peer_batches_it_issued(mocker):
+    """The batch count comes back from ``_warm_peers`` rather than being discarded."""
+    shared = FakePeer("site-1", "LocationSite")
+    nodes_by_kind = {"KindA": [FakeNode("KindA", "a1", peer=shared)]}
+    processor, _wrapper = _make_processor(mocker, nodes_by_kind, attrs=["name", "site.name"])
+    processor.display = mocker.MagicMock()
+    mocker.patch.object(processor, "resolve_node_mapping", return_value={"id": "x"})
+
+    processor.fetch_and_process(nodes={"KindA": {}})
+
+    cost_line = next(line for line in _display_lines(processor.display) if "Inventory fetch cost" in line)
+    assert "in 1 batch(es)" in cost_line
+
+
+def test_run_cost_report_is_silent_without_a_display(mocker):
+    """No Display attached -- reporting must be a no-op, not an AttributeError."""
+    nodes_by_kind = {"KindA": [FakeNode("KindA", "a1")]}
+    processor, _wrapper = _make_processor(mocker, nodes_by_kind)
+    mocker.patch.object(processor, "resolve_node_mapping", return_value={"id": "x"})
+
+    assert processor.display is None
+    assert processor.fetch_and_process(nodes={"KindA": {}}) is not None
+
+
+def test_run_cost_breakdown_is_emitted_at_vvv_not_at_v(mocker):
+    """The totals ride -v; the per-kind detail rides -vvv.
+
+    Anyone running an inventory at -v wants one line, not a page. The breakdown is
+    only useful once the total already looks wrong, so it sits a level deeper.
+    """
+    shared = FakePeer("site-1", "LocationSite")
+    nodes_by_kind = {"KindA": [FakeNode("KindA", "a1", peer=shared)]}
+    processor, _wrapper = _make_processor(mocker, nodes_by_kind, attrs=["name", "site.name"])
+    processor.display = mocker.MagicMock()
+    mocker.patch.object(processor, "resolve_node_mapping", return_value={"id": "x"})
+
+    processor.fetch_and_process(nodes={"KindA": {}})
+
+    at_v = _display_lines(processor.display, "v")
+    at_vvv = _display_lines(processor.display, "vvv")
+    assert [line for line in at_v if "Inventory fetch cost:" in line]
+    assert not [line for line in at_v if "by kind" in line]
+    assert [line for line in at_vvv if "Inventory fetch cost, by kind:" in line]
+    assert [line for line in at_vvv if "host kind KindA: 1 node(s)" in line]
+    assert [line for line in at_vvv if "peer kind LocationSite:" in line]
+
+
+def test_run_cost_breakdown_distinguishes_narrowed_from_wide_from_generic():
+    """Three cases that must not be described the same way.
+
+    A kind with no ``include`` is wide by request. A kind answered via a requested
+    generic has no projection of its own, and calling that "not narrowed" would be a
+    lie. Only the third is actually narrowed.
+    """
+    from ansible_collections.opsmill.infrahub.plugins.module_utils.peers import PeerWarmer
+    from ansible_collections.opsmill.infrahub.plugins.module_utils.projection import NodeProjection
+
+    fetched = iu.HostFetch()
+    fetched.nodes = [FakeNode("Wide", "w1"), FakeNode("Concrete", "c1"), FakeNode("Narrow", "n1")]
+    fetched.projections = {
+        "Wide": NodeProjection(attrs=["name"], roots={"name"}, include=None, exclude=None, narrowed=False),
+        "Narrow": NodeProjection(
+            attrs=["name"], roots={"name"}, include=["name"], exclude=["a", "b", "c"], narrowed=True
+        ),
+    }
+    warmer = PeerWarmer(fetch=lambda **kw: [], store=None)
+    warmer.stats = {"LocationSite": {"requested": 130, "batches": 3, "loaded": 130, "failed": 0}}
+
+    lines = iu.InfrahubNodesProcessor._run_cost_breakdown(fetched=fetched, warmer=warmer)
+
+    joined = "\n".join(lines)
+    assert "host kind Wide: 1 node(s), no include given, full attribute set requested" in joined
+    assert "host kind Concrete: 1 node(s), answered via a requested generic" in joined
+    assert "host kind Narrow: 1 node(s), requested [name], 3 field(s) excluded" in joined
+    assert "peer kind LocationSite: 130 id(s) referenced, 3 batch(es), 130 loaded" in joined
+
+
+def test_run_cost_breakdown_reports_failed_peer_batches():
+    """A peer kind that failed must say so, or its zero shows up as a mystery."""
+    from ansible_collections.opsmill.infrahub.plugins.module_utils.peers import PeerWarmer
+
+    warmer = PeerWarmer(fetch=lambda **kw: [], store=None)
+    warmer.stats = {"LocationSite": {"requested": 60, "batches": 0, "loaded": 0, "failed": 2}}
+
+    lines = iu.InfrahubNodesProcessor._run_cost_breakdown(fetched=iu.HostFetch(), warmer=warmer)
+
+    assert any("2 batch(es) failed" in line for line in lines)
+
+
+def test_run_cost_breakdown_is_empty_when_there_is_nothing_to_say():
+    """No header without content -- an empty run should not emit a bare heading."""
+    from ansible_collections.opsmill.infrahub.plugins.module_utils.peers import PeerWarmer
+
+    warmer = PeerWarmer(fetch=lambda **kw: [], store=None)
+    assert iu.InfrahubNodesProcessor._run_cost_breakdown(fetched=iu.HostFetch(), warmer=warmer) == []
+
+
 def test_a_swallowed_fetch_is_a_failure_not_an_empty_result(mocker):
     """The wrapper returns ``None`` instead of raising, and that still has to fail loudly.
 

--- a/tests/unit/plugins/module_utils/test_metrics.py
+++ b/tests/unit/plugins/module_utils/test_metrics.py
@@ -1,0 +1,79 @@
+"""Unit tests for the run-cost counter.
+
+The counter exists so a report of "the inventory is slow" can arrive as a number.
+Its correctness is unglamorous but load-bearing: an off-by-one or a silently
+detached counter turns the diagnostic back into an anecdote.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from ansible_collections.opsmill.infrahub.plugins.module_utils import metrics
+
+
+def test_counter_starts_at_zero():
+    assert metrics.RequestCounter().responses == 0
+
+
+def test_counter_increments_once_per_response():
+    counter = metrics.RequestCounter()
+    for _ in range(3):
+        counter.record(response=None)
+    assert counter.responses == 3
+
+
+def test_counter_ignores_the_response_it_is_given():
+    """The response is not retained -- the counter must not hold request bodies.
+
+    Recording is called for every response the SDK receives, tokens and payloads
+    included. Keeping any of it would put credentials in whatever holds the counter.
+    """
+    counter = metrics.RequestCounter()
+    counter.record(response=SimpleNamespace(content=b"secret", status_code=200))
+    assert counter.responses == 1
+    # The count is the only state. Anything else here would be a retained response.
+    assert list(vars(counter)) == ["responses"]
+
+
+def test_reset_zeroes_the_counter():
+    counter = metrics.RequestCounter()
+    counter.record(response=None)
+    counter.reset()
+    assert counter.responses == 0
+
+
+def test_module_has_no_runtime_sdk_dependency():
+    """Plugin files must import without ``infrahub-sdk`` installed.
+
+    ``httpx`` appears only in an annotation, under ``TYPE_CHECKING``, so it must not
+    be bound at module level. If someone later moves that import out of the guard,
+    ``ansible-test sanity`` fails on a machine without the SDK -- this catches it first.
+    """
+    assert "httpx" not in vars(metrics)
+    assert "infrahub_sdk" not in vars(metrics)
+
+
+def test_request_count_reads_an_attached_counter():
+    counter = metrics.RequestCounter()
+    counter.record(response=None)
+    assert metrics.request_count(SimpleNamespace(request_counter=counter)) == 1
+
+
+def test_request_count_is_none_when_no_counter_is_attached():
+    """A wrapper built through ``__new__`` has no counter, and that is not an error.
+
+    The integration tests build one that way to skip re-authenticating. Reporting has
+    to degrade to "unavailable" rather than raising, or a diagnostic breaks the run
+    it was added to diagnose.
+    """
+    assert metrics.request_count(SimpleNamespace()) is None
+
+
+def test_request_count_rejects_a_non_integer_counter():
+    """A MagicMock auto-attribute answers to ``.responses`` with another mock.
+
+    Without the type check that mock would be reported as a request count, so every
+    mock-based test would print a nonsense number and nobody would notice.
+    """
+    assert metrics.request_count(SimpleNamespace(request_counter=SimpleNamespace(responses="lots"))) is None

--- a/tests/unit/plugins/module_utils/test_metrics.py
+++ b/tests/unit/plugins/module_utils/test_metrics.py
@@ -36,13 +36,6 @@ def test_counter_ignores_the_response_it_is_given():
     assert list(vars(counter)) == ["responses"]
 
 
-def test_reset_zeroes_the_counter():
-    counter = metrics.RequestCounter()
-    counter.record(response=None)
-    counter.reset()
-    assert counter.responses == 0
-
-
 def test_module_has_no_runtime_sdk_dependency():
     """Plugin files must import without ``infrahub-sdk`` installed.
 

--- a/tests/unit/plugins/module_utils/test_peers.py
+++ b/tests/unit/plugins/module_utils/test_peers.py
@@ -255,3 +255,36 @@ def test_ledger_ignores_a_peer_the_warmer_already_loaded_in_full():
 
     assert ledger.pending == {}
     assert not ledger
+
+
+def test_warm_counts_a_swallowed_batch_as_failed_not_as_a_batch():
+    """A ``None`` return is a failure the wrapper already swallowed.
+
+    ``handle_infrahub_exceptions_decorator`` logs and returns ``None`` rather than
+    raising whenever a Display is attached, which is always in the inventory, so the
+    ``except`` never fires. Counting it as a batch that worked hides the failure.
+    """
+    warmer = _warmer(fetch=lambda **kwargs: None)
+
+    calls = warmer.warm({"LocationSite": {"s1"}})
+
+    assert calls == 0
+    assert warmer.stats["LocationSite"]["batches"] == 0
+    assert warmer.stats["LocationSite"]["failed"] == 1
+
+
+def test_warm_counts_each_loaded_id_once_across_passes():
+    """``warm`` runs twice a run, and the by-kind tally must still reconcile.
+
+    The summary reports ``len(warmer.loaded)``, a deduplicated set, so counting every
+    returned node would overshoot it for any id that comes back in both passes.
+    """
+    warmer = _warmer()
+
+    warmer.warm({"LocationSite": {"s1", "s2"}})
+    warmer.warm({"LocationSite": {"s1"}})
+
+    assert warmer.loaded == {"s1", "s2"}
+    assert warmer.stats["LocationSite"]["loaded"] == 2
+    # Both passes were issued, so both are still charged as batches.
+    assert warmer.stats["LocationSite"]["batches"] == 2


### PR DESCRIPTION
Stacked on #374 — targets `perf/inventory-projection-and-peer-batching`, not `develop`, because it builds on `PeerWarmer` / `_warm_peers` / `_resolve_hosts`, none of which exist on `develop` yet.

## What

At `-v`, a run now states what it cost:

```
Inventory fetch cost: 15 request(s) to Infrahub, 41 related node(s) loaded in 2 batch(es)
```

At `-vvv` the totals are followed by the breakdown behind them:

```
Inventory fetch cost, by kind:
  host kind DcimDevice: 652 node(s), requested [name, primary_address, site], 28 field(s) excluded
  peer kind LocationSite: 130 id(s) referenced, 3 batch(es), 130 loaded
```

A total that looks wrong is only actionable once you can see which kind produced it — whether the query was narrowed at all, whether a generic answered with concrete kinds, and which peer kind cost the batches. A failed peer batch is named too, so a kind reporting `0 loaded` is not a mystery.

Silent at default verbosity. A run served entirely from cache never reaches this code.

## Why here and not above the wrapper

The SDK paginates inside `client.filters()`, **below** `InfrahubclientWrapper`. Counting the wrapper's own calls reports fetch *operations* and misses the pages — precisely the part that grows with the estate. On the 652-device instance that is the difference between reporting 3 and reporting 15.

`Recorder` is a supported SDK extension point: a runtime-checkable protocol with one method, `record(response)`, invoked from `InfrahubClientSync._record` on every HTTP response. Passing a `RequestCounter` as `Config.custom_recorder` keeps the wrapper the sole constructor and configurer of the client, so Principle IV holds. The alternative — reassigning `client.execute_graphql`, as the tests do — is the one that would bypass it.

## Two properties worth knowing

- **It counts every HTTP round-trip**, schema lookups included. Those are REST, not GraphQL, so this figure is legitimately higher than a `count_graphql` count. The integration test asserts `reported >= graphql_calls`, never equality.
- **It is a delta**, snapshotted across the run. The counter lives on the client, which outlives one `fetch_and_process`, so reporting its absolute value would charge this run for an earlier one.

## Also included

`specs/001-inventory-fetch-performance/` — a retroactive specification of the whole performance effort (spec, plan, tasks, research, data model, contracts, quickstart). The session retrospective that produced #376–#380 is deliberately not included.

## Verification

- 127 unit tests, 11 integration tests (testcontainers, ~1m54s)
- `ruff check` / `ruff format --check` / `mypy .` / `yamllint` / `rumdl` clean

Note that no integration test runs on a PR — `integration-testcontainers` is gated on `schedule` / `workflow_dispatch` — so the integration figures above are local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reports inventory run cost at raised verbosity and reconciles totals with the per-kind breakdown. Previously silent and sometimes inconsistent; now -v prints totals (including failed batches) and -vvv prints host and peer details with correct labels.

- Counts HTTP responses with `RequestCounter` via `Config.custom_recorder`; reports a per-run delta via `request_count`. Includes schema calls; if no counter is attached, shows “unavailable.” Default verbosity stays silent; cache-only runs do not report.
- Peer accounting: treat swallowed fetches as failed (not as batches); count each loaded id once across warm and refill passes so the -vvv tally matches the -v total.
- Reporting: -v names failed batches and reports “node(s) loaded”; -vvv classifies refilled host kinds as hosts. Runs that match no hosts still report cost.
- Internal: `_warm_peers` returns batch count and accumulates per-kind stats; `InfrahubclientWrapper` exposes `request_counter`.
- Tests/specs: add unit tests for accounting, adjust the integration delta baseline, drop `RequestCounter.reset()`, and update specs to cover batches. No user-facing options or migrations.

<sup>Written for commit db23c8ab70e085ce0b447a01e31d3c0fd9ab8b0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-ansible/pull/381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

