### PR TITLE
docs: close the gaps a session retrospective found in the agent context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,5 +8,7 @@ docker-compose.yml
 .claude/
 .specify/
 dev/
+.pytest_collections/
+specs/
 **/.ruff_cache
 **/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ secrets.yaml
 **/node_modules/
 docs/.docusaurus/
 docs/build/
+
+# Local spec-kit state: points at the feature the current session is working on.
+# Per-checkout, not shared.
+.specify/feature.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This file is the portable router: repo-wide facts every agent needs up front. De
 | Component | Version/Tool |
 |-----------|-------------|
 | Python | >=3.11, <3.15 |
-| ansible-core | >=2.18 |
+| ansible-core | >=2.19.11rc1 |
 | infrahub-sdk | >=1.19.0, <2.0 |
 | Linter/Formatter | Ruff (pinned in pyproject.toml) |
 | Tests | pytest, ansible-test sanity (Docker-based) |
@@ -25,7 +25,7 @@ This file is the portable router: repo-wide facts every agent needs up front. De
 ## Commands
 
 ```bash
-invoke lint            # Check (ruff + yamllint)
+invoke lint            # Check (ruff + yamllint + rumdl) -- NOT mypy, see below
 invoke format          # Auto-fix (ruff)
 invoke tests-sanity    # Ansible compliance (boilerplate, docs, imports)
 invoke tests-unit      # Unit tests
@@ -43,8 +43,11 @@ All tests run in Docker. Run checks as you go, not just at the end:
 | any plugin file (`plugins/**/*.py`) | `invoke format` → `invoke lint` → `invoke tests-sanity` |
 | module logic or `module_utils` | also `invoke tests-unit` |
 | module docstrings (DOCUMENTATION / EXAMPLES / RETURN) | `invoke generate-doc` |
+| any Python file | also `uv run mypy .` -- `invoke lint` does **not** run it, CI does |
 
-Full verification before a PR: `invoke format && invoke lint && invoke tests-sanity && invoke tests-unit && invoke generate-doc`.
+Full verification before a PR: `invoke format && invoke lint && uv run mypy . && invoke tests-sanity && invoke tests-unit && invoke generate-doc`.
+
+`uv run mypy .` is listed separately because `invoke lint` does not include it while CI's `python-lint` job does — a green `invoke lint` is not a green CI. Note also that mypy currently **excludes** `plugins/module_utils/infrahub_utils.py`, so the collection's largest file is not typechecked at all.
 
 New-module walkthrough: [dev/guides/creating-a-module.md](dev/guides/creating-a-module.md). Test execution detail: [dev/guides/running-tests.md](dev/guides/running-tests.md).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ This file is the portable router: repo-wide facts every agent needs up front. De
 ## Commands
 
 ```bash
-invoke lint            # Check (ruff + yamllint + rumdl) -- NOT mypy, see below
+invoke lint            # autoflake (rewrites files!) + ruff + yamllint + rumdl -- NOT mypy, see below
 invoke format          # Auto-fix (ruff)
 invoke tests-sanity    # Ansible compliance (boilerplate, docs, imports)
 invoke tests-unit      # Unit tests
@@ -48,6 +48,8 @@ All tests run in Docker. Run checks as you go, not just at the end:
 Full verification before a PR: `invoke format && invoke lint && uv run mypy . && invoke tests-sanity && invoke tests-unit && invoke generate-doc`.
 
 `uv run mypy .` is listed separately because `invoke lint` does not include it while CI's `python-lint` job does — a green `invoke lint` is not a green CI. Note also that mypy currently **excludes** `plugins/module_utils/infrahub_utils.py`, so the collection's largest file is not typechecked at all.
+
+`invoke lint` is not purely a check: its first step is `autoflake --in-place --remove-all-unused-imports --remove-unused-variables`, which edits your working tree before ruff ever runs. Expect it to leave modified files behind, and review that diff rather than assuming a linter only reported.
 
 New-module walkthrough: [dev/guides/creating-a-module.md](dev/guides/creating-a-module.md). Test execution detail: [dev/guides/running-tests.md](dev/guides/running-tests.md).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,3 +4,11 @@
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
 <!-- SPECKIT END -->
+
+## Active Technologies
+
+- Python >=3.11, <3.15 (`pyproject.toml`) + `ansible-core>=2.19.11rc1`; `infrahub-sdk[all]>=1.19.0,<2.0` (synchronous client only) (001-inventory-fetch-performance)
+
+## Recent Changes
+
+- 001-inventory-fetch-performance: Added Python >=3.11, <3.15 (`pyproject.toml`) + `ansible-core>=2.19.11rc1`; `infrahub-sdk[all]>=1.19.0,<2.0` (synchronous client only)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,4 +11,4 @@ shell commands, and other important information, read the current plan
 
 ## Recent Changes
 
-- 001-inventory-fetch-performance: Added Python >=3.11, <3.15 (`pyproject.toml`) + `ansible-core>=2.19.11rc1`; `infrahub-sdk[all]>=1.19.0,<2.0` (synchronous client only)
+- 001-inventory-fetch-performance: Cut dynamic inventory fetch round-trips — query projection, bounded peer fetches, batched refill

--- a/dev/guidelines/python.md
+++ b/dev/guidelines/python.md
@@ -119,14 +119,31 @@ ruff check --fix .
 ## Python Version
 
 ```toml
-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.15"
 ```
 
-Target Python 3.10+ but maintain the Ansible `__future__` imports and `__metaclass__ = type` boilerplate for `ansible-test sanity` compliance.
+Target Python 3.11+ but maintain the Ansible `__future__` imports and `__metaclass__ = type` boilerplate for `ansible-test sanity` compliance.
 
 ## Type Hints
 
 Use modern type hints (`str | None` not `Optional[str]`). The `from __future__ import annotations` import is present in all files.
+
+### mypy
+
+CI runs `uv run mypy .` as part of the `python-lint` job. **`invoke lint` does not**, so a clean
+`invoke lint` can still fail CI — run mypy explicitly before opening a PR:
+
+```bash
+uv run mypy .
+```
+
+Two things to know about the current configuration (`[tool.mypy]` in `pyproject.toml`):
+
+- `warn_return_any`, `disallow_untyped_defs`, and `warn_unused_ignores` are all on, so an unannotated
+  helper or a stale `# type: ignore` fails the build.
+- `plugins/module_utils/infrahub_utils.py` is **excluded**. That is the largest file in the collection,
+  so a change confined to it gets no type checking whatsoever. Do not read "mypy passed" as "this file
+  is checked".
 
 ## Dependencies
 

--- a/dev/guidelines/testing.md
+++ b/dev/guidelines/testing.md
@@ -167,11 +167,55 @@ tests/
 
 Integration tests are Ansible playbooks that exercise the full module → API path.
 
+There is a second kind. `tests/integration/processor/` and `tests/integration/inventory/` use pytest
+against a real Infrahub started by the SDK's testcontainers helper. They need their own dependency group
+and a handful of flags — see
+[../guides/running-tests.md](../guides/running-tests.md) for the exact invocation and why each flag is
+required.
+
+## Practices Worth Following
+
+These come from defects that reached a branch and were caught late, not from theory.
+
+### Verify a new test by collection, not by the pass count
+
+A test method attached to the wrong class still leaves a green suite — the count simply goes down by
+one, which nobody notices. After adding or moving a test, confirm the runner can see it:
+
+```bash
+uv run pytest tests/unit --collect-only -q | grep <your_test_name>
+```
+
+"N passed" answers whether the tests that ran succeeded. It does not answer whether your test ran.
+
+### Mutation-check a test that claims to protect a behaviour
+
+Before writing "this test guards X" in a docstring, disable X and confirm the test fails. A test can
+pass for reasons unrelated to the thing it names — in this collection an integration test asserting that
+peer warming resolved a generic-peer attribute passed with warming disabled, because a separate refill
+path recovered the value. The docstring was the defect, not the code.
+
+### Re-verify remembered facts against the code
+
+Notes carried between sessions go stale. A refetch path recorded as "dead code, does not fire" turned
+out to fire once per node — 653 times on a 652-device estate — and was the only thing resolving
+attributes declared through a generic peer. Removing it on the strength of the note would have silently
+emptied those attributes. Confirm behaviour by instrumenting or testing it before acting on a memory.
+
+### Derive round-trip budgets, do not hardcode them
+
+Integration tests that assert a request count share a container and accumulate data, so a fixed ceiling
+quietly stops meaning anything. Compute the budget from `pagination_size` and the actual result size,
+and record which SDK and image version a measured budget came from.
+
 ## CI Pipeline
 
 Tests run on every PR to `develop`:
 
-1. **Linter job** — Ruff check + format, yamllint, Vale
+1. **Linter job** — Ruff check + format, **mypy**, yamllint, rumdl, Vale
 2. **Ansible linter and tests job** — ansible-lint, sanity tests, unit tests
+
+`invoke lint` covers ruff, yamllint, and rumdl — but **not mypy**. Run `uv run mypy .` separately, or
+the first sign of a type error will be a red CI job.
 
 The CI workflow is in `.github/workflows/trigger-pr-develop.yml`.

--- a/dev/guides/running-tests.md
+++ b/dev/guides/running-tests.md
@@ -118,11 +118,11 @@ Integration tests use Ansible playbooks in `tests/integration/targets/`.
 run through pytest directly and need their own dependency group:
 
 ```bash
-uv sync --group integration
+uv sync --no-default-groups --group integration
 export INFRAHUB_TESTING_IMAGE_VER=1.9.9
 
 uv run --no-default-groups --group integration pytest tests/integration/processor \
-  -m integration -p no:pytest-infrahub-performance-test -q
+  -m "integration and not measurement" -p no:pytest-infrahub-performance-test -q
 ```
 
 Four details, each of which will otherwise cost you a failed run:

--- a/dev/guides/running-tests.md
+++ b/dev/guides/running-tests.md
@@ -111,11 +111,70 @@ Integration tests require a running Infrahub instance. The `integration` Docker 
 
 Integration tests use Ansible playbooks in `tests/integration/targets/`.
 
+### Testcontainers Suites
+
+`tests/integration/processor/` and `tests/integration/inventory/` do not use the Docker Compose
+`integration` service. They spin up a real Infrahub with the SDK's `TestInfrahubDocker` helper, so they
+run through pytest directly and need their own dependency group:
+
+```bash
+uv sync --group integration
+export INFRAHUB_TESTING_IMAGE_VER=1.9.9
+
+uv run --no-default-groups --group integration pytest tests/integration/processor \
+  -m integration -p no:pytest-infrahub-performance-test -q
+```
+
+Four details, each of which will otherwise cost you a failed run:
+
+- **`--no-default-groups` is mandatory.** `dev` and `integration` are declared as conflicting groups in
+  `pyproject.toml` (the `integration` group pulls `prefect-client`, which pins `cachetools<7`, while
+  `dev` needs `tox` at `cachetools>=7`). Without it, uv refuses outright:
+  `Groups 'dev' (enabled by default) and 'integration' are incompatible`.
+- **`-p no:pytest-infrahub-performance-test`.** That plugin's startup hook calls `psutil.cpu_freq()`,
+  which raises on macOS and aborts collection.
+- **`INFRAHUB_TESTING_IMAGE_VER`** selects the Infrahub image. It has no default.
+- **Two markers, two audiences.** `integration` rides the PR gate. `measurement` additionally marks the
+  heavy round-trip benchmarks in `test_fetch_roundtrip_measurement.py`, which load a schema and wait for
+  convergence — too slow for a standard runner, so they run on scheduled builds only.
+
+Fixtures are **class-scoped**, so every additional test class starts another Infrahub container. Adding
+a test to an existing class rather than a new one is worth roughly a minute of PR wall-clock.
+
+### Run pytest and sanity in separate passes
+
+Running pytest creates `.pytest_collections/`, which contains a symlink to the absolute path of your
+checkout. That directory is in `.gitignore`, and is now also in `.dockerignore` — it was not, and the
+consequence was `invoke tests-sanity` failing inside the Docker build with:
+
+```text
+[ERROR]: Failed to find the target path '/Users/.../infrahub' for the symlink
+         '/usr/src/app/.pytest_collections/ansible_collections/opsmill/infrahub'
+failed to solve: process "/bin/sh -c ansible-galaxy collection build --output-path ./dist/ ."
+         did not complete successfully: exit code: 1
+```
+
+The error names `ansible-galaxy`, not pytest, so it reads like a packaging problem. If you see it after
+a dependency bump or on an older checkout, `rm -rf .pytest_collections` and re-run.
+
+### Comparing two branches
+
+Use `git worktree`, not `git stash`. `uv run` rewrites `uv.lock` as a side effect, so the tree is dirty
+again the moment you run anything — which blocks `git stash pop` and can make `git checkout` fail
+silently enough that you carry on measuring the branch you thought you had left.
+
+```bash
+git worktree add ../infrahub-baseline develop
+```
+
 ## Linting (Not Tests, But Related)
 
 ```bash
-# Run all linters (ruff + yamllint)
+# Run all linters (ruff check + ruff format + yamllint + rumdl) -- does NOT run mypy
 invoke lint
+
+# Type checking is a separate command, and CI runs it
+uv run mypy .
 
 # Auto-fix formatting
 invoke format

--- a/dev/knowledge/infrahub-sdk-usage.md
+++ b/dev/knowledge/infrahub-sdk-usage.md
@@ -268,8 +268,9 @@ attributes requested. Verified by rendering the query both ways: with and withou
 produced byte-identical output.
 
 The consequence is that a user writing `include: [name]` pays for every attribute on the kind unless the
-caller computes the complement and passes it as `exclude`. That translation is what
-`plugins/module_utils/projection.py` exists to do.
+caller computes the complement itself — "everything the schema declares, minus what the user asked for" —
+and passes that as `exclude`. `include` still has to carry the top-level name of any cardinality-many
+relationship that must be prefetched, so the two lists are derived together, not either/or.
 
 ### A relationship's peer payload is projected off the *declared* peer schema
 
@@ -287,9 +288,9 @@ with `hierarchy` set (`hierarchical_relationship_schemas`). They are **not** in 
 an exclude list computed as "everything the schema declares, minus what the user asked for" never
 reaches them — and `_process_hierarchical_fields` adds all four to the query whenever
 `prefetch_relationships` is on. A narrowed query against Location, Organization or an IPAM prefix
-therefore still drags two full hierarchies down on every page unless the four names are excluded
-explicitly. `NodeProjection.HIERARCHICAL_FIELDS` does that; naming them on a non-hierarchical kind is
-free, because the SDK only ever tests membership in `exclude`.
+therefore still drags two full hierarchies down on every page unless the four names are added to
+`exclude` explicitly. Name them unconditionally: doing so on a non-hierarchical kind is free, because the
+SDK only ever tests membership in `exclude`.
 
 ### The wrapper swallows exceptions whenever a Display is attached
 

--- a/dev/knowledge/infrahub-sdk-usage.md
+++ b/dev/knowledge/infrahub-sdk-usage.md
@@ -255,3 +255,79 @@ The SDK wrapper respects these environment variables as fallbacks:
 |----------|---------|
 | `INFRAHUB_ADDRESS` | API endpoint URL |
 | `INFRAHUB_API_TOKEN` | Authentication token |
+
+## SDK Behaviours That Surprise
+
+Each of these cost real debugging time. They are properties of `infrahub-sdk`, not of this collection,
+so they can change under a version bump — re-verify rather than trusting this list blindly.
+
+### `include` does not narrow a query
+
+Only `exclude` narrows. `include` opts cardinality-many relationships *in*; it does not restrict the
+attributes requested. Verified by rendering the query both ways: with and without `include`, the SDK
+produced byte-identical output.
+
+The consequence is that a user writing `include: [name]` pays for every attribute on the kind unless the
+caller computes the complement and passes it as `exclude`. That translation is what
+`plugins/module_utils/projection.py` exists to do.
+
+### A relationship's peer payload is projected off the *declared* peer schema
+
+When a relationship declares a generic as its peer (`Device.location` → a location generic), the inline
+peer payload carries only what the **generic** exposes. An attribute that lives on the concrete kind is
+never requested and never arrives, no matter how many times the host query is retried.
+
+This is the most common shape in real schemas and the source of most apparent "the value is empty"
+reports. The fix is to load the peers by id in a second, batched pass — not to retry the host query.
+
+### Hierarchy fields escape an `exclude` complement built from the schema
+
+`parent`, `children`, `ancestors` and `descendants` are pseudo-schemas the SDK synthesises for any kind
+with `hierarchy` set (`hierarchical_relationship_schemas`). They are **not** in `relationship_names`, so
+an exclude list computed as "everything the schema declares, minus what the user asked for" never
+reaches them — and `_process_hierarchical_fields` adds all four to the query whenever
+`prefetch_relationships` is on. A narrowed query against Location, Organization or an IPAM prefix
+therefore still drags two full hierarchies down on every page unless the four names are excluded
+explicitly. `NodeProjection.HIERARCHICAL_FIELDS` does that; naming them on a non-hierarchical kind is
+free, because the SDK only ever tests membership in `exclude`.
+
+### The wrapper swallows exceptions whenever a Display is attached
+
+`handle_infrahub_exceptions_decorator` is applied to every public `InfrahubclientWrapper` method in
+`__init__`. With a `Display` (always, in the inventory) it logs and **returns `None`**; only without one
+does it re-raise. So `try: ... except Exception` around a wrapper call is dead code in the inventory
+path — check for a `None` return instead, and treat it as distinct from an empty list.
+
+### The non-parallel pager costs an extra empty request on a full page
+
+`filters(parallel=False)` stops only once `count - (offset + pagination_size)` goes negative, so a chunk
+of exactly `pagination_size` triggers one more, empty round-trip. Batch ids at `pagination_size - 1`.
+
+### `Config.custom_recorder` is the supported instrumentation hook
+
+`Recorder` is a runtime-checkable protocol with a single method, `record(response: httpx.Response)`,
+invoked from `InfrahubClientSync._record` on every HTTP response — below pagination. Passing a counter
+as `custom_recorder` is how to measure real round-trips without monkeypatching `execute_graphql`.
+
+Note it counts *every* response, REST schema lookups included, so the figure is legitimately higher than
+a GraphQL-only count.
+
+### Raising `pagination_size` does not make things faster
+
+Measured on a ~650-device estate: 50 → 500 cut the request count from 20 to 4 and moved wall-clock the
+wrong way, 7.10s → 7.60s. Fewer, larger pages is not a win here. Concurrency is the lever that helped.
+
+## Naming Trap: `self.client.client`
+
+`InfrahubclientWrapper` holds the SDK client as `.client`, and the processors hold the *wrapper* as
+`.client`. So inside `InfrahubNodesProcessor`:
+
+```python
+self.client  # the InfrahubclientWrapper
+self.client.client  # the raw InfrahubClientSync
+self.client.client.store  # the SDK's NodeStore
+```
+
+`self.client.client` reads like a typo and is not one. A review bot flagged it as such during the
+inventory performance work; applying the suggested "fix" broke three tests. Verify with
+`processor.client.client.store is wrapper.client.store` before changing anything in this area.


### PR DESCRIPTION
Independent of #374 and #381 — branches off `develop` and can merge on its own.

Each of these fixes something that cost real time, not something that merely reads better.

## `invoke lint` is not CI

`invoke lint` runs ruff, yamllint and rumdl. CI's `python-lint` job additionally runs **mypy**. Nothing in `AGENTS.md` or `dev/` said so, and a `no-any-return` reached CI as a result. Both now say it — and say the harder half too: mypy **excludes `plugins/module_utils/infrahub_utils.py`**, so the largest file in the collection is not typechecked at all and "mypy passed" means less than it looks. Lifting that exclusion is #378.

## The testcontainers suites were undocumented

`dev/guides/running-tests.md` still described integration testing as Ansible playbooks under `tests/integration/targets/`. It now covers the `dev`/`integration` group conflict (a hard uv error, not a warning), `INFRAHUB_TESTING_IMAGE_VER`, the perf-plugin opt-out, the `measurement`-vs-PR-gate marker split, and the per-class container cost.

## `.pytest_collections/` broke the sanity build

It was in `.gitignore` but not `.dockerignore`, so running pytest before `invoke tests-sanity` poisoned the Docker build context and failed with a dangling-symlink error that names `ansible-galaxy`, not pytest. Fixed, and documented with the literal error text so it is searchable.

## SDK behaviours that surprise

`dev/knowledge/infrahub-sdk-usage.md` gains five: `include` never narrows a query, a relationship's peer payload is projected off the *declared* peer schema, the non-parallel pager costs an extra request on a full page, `Config.custom_recorder` is the supported instrumentation hook, and raising `pagination_size` measurably does not help (50 to 500 cut requests 20 to 4 and moved wall-clock 7.10s to 7.60s). Plus the `self.client.client` naming trap — a review bot flagged it as a typo and it is not one; applying the "fix" broke three tests. That rename is #379.

## Testing practices

`dev/guidelines/testing.md` gains four, all earned this session: verify a new test by `--collect-only` rather than the pass count (a misplaced test still leaves a green suite, and did), mutation-check any test whose docstring claims it protects a behaviour, re-verify remembered facts against the code, and derive round-trip budgets rather than hardcoding them.

## Also

Stale version ranges in `dev/guidelines/python.md` corrected against `pyproject.toml`. The same drift in the constitution is #376. `.specify/feature.json` is now ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies agent docs to match CI and removes pitfalls that caused red builds. Previously `invoke lint` implied parity with CI and pytest artifacts leaked into Docker; now we require local `mypy`, warn that `invoke lint` rewrites files, and ignore pytest outputs, and we fix inaccurate commands/references found in review.

- CI parity: document that `invoke lint` runs ruff/yamllint/`rumdl` only; require `uv run mypy .`; note `mypy` currently excludes `plugins/module_utils/infrahub_utils.py`; call out that `invoke lint` runs `autoflake` in-place and will modify files.
- Integration suites: add `tests/integration/{processor,inventory}` guidance using `uv sync --no-default-groups --group integration`, `INFRAHUB_TESTING_IMAGE_VER`, `-p no:pytest-infrahub-performance-test`, and `-m "integration and not measurement"`; note class-scoped containers add startup cost.
- Sanity build reliability: add `.pytest_collections/` and `specs/` to `.dockerignore` to prevent dangling-symlink failures; if you hit the old error, remove `.pytest_collections/` and re-run.
- SDK usage: document non-intuitive behaviors (e.g., `include` does not narrow, generic-peer projection limits inline fields, hierarchy pseudo-fields require explicit `exclude`, wrapper returns `None` on error, non-parallel pager’s extra empty request, `Config.custom_recorder` for instrumentation, higher `pagination_size` isn’t faster, and the `self.client.client` naming trap).
- Testing practices: verify new tests via `--collect-only`, mutation-check behavior claims, re-validate remembered facts, and derive round-trip budgets instead of hardcoding.
- Versions and ignores: align to Python `>=3.11,<3.15`, `ansible-core>=2.19.11rc1`, reaffirm `infrahub-sdk>=1.19.0,<2.0`, and ignore `.specify/feature.json`.
- Corrections: remove references to files not on `develop` and fix the integration test command/marker to match the documented constraints.

<sup>Written for commit b99b5946d839ea1117105961cd07fe64bcf85d46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-ansible/pull/382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

