### PR TITLE
fix(inventory): resolve nested traversal through generic peers

### DIFF
--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -598,9 +598,9 @@ if HAS_INFRAHUBCLIENT:
         ):
             self.client = client
             self.display = display
-            # Peer ids already refetched by _peer_needs_concrete_refetch, so a
-            # genuinely empty relationship doesn't refetch once per host node.
-            self._refetched_peer_ids: set[str] = set()
+            # Peer ids fetched in full this run (store-miss or concrete refetch),
+            # so a genuinely empty relationship doesn't refetch once per host node.
+            self._fully_fetched_peer_ids: set[str] = set()
 
         def _handle_display(
             self, message: str, exception: Exception | None = None, level: str | None = "ERROR"
@@ -683,15 +683,16 @@ if HAS_INFRAHUBCLIENT:
             typed by its concrete kind (from ``__typename``) but only carries the
             generic's fields: a requested concrete-only relationship then exists on
             the schema yet holds no id, and the nested traversal would silently
-            resolve empty. Refetched ids are remembered so a genuinely empty
-            relationship doesn't trigger a refetch for every host traversing it.
+            resolve empty. Ids in ``_fully_fetched_peer_ids`` are skipped — the
+            caller records them only after a successful full fetch, so a genuinely
+            empty relationship is refetched once per run while a failed refetch can
+            still be retried by later hosts.
             """
-            if related_node.id in self._refetched_peer_ids:
+            if related_node.id in self._fully_fetched_peer_ids:
                 return False
             for root_attr in {attr.split(".", 1)[0] for attr in nested_attrs}:
                 node_attr = getattr(related_node, root_attr, None)
                 if isinstance(node_attr, RelatedNodeSync) and node_attr.id is None:
-                    self._refetched_peer_ids.add(related_node.id)
                     return True
             return False
 
@@ -715,6 +716,8 @@ if HAS_INFRAHUBCLIENT:
                 if not related_node:
                     peer.fetch()
                     related_node = peer.peer
+                    if related_node is not None and related_node.id:
+                        self._fully_fetched_peer_ids.add(related_node.id)
 
                 if not related_node or not hasattr(related_node._schema, "attribute_names"):
                     continue
@@ -746,6 +749,8 @@ if HAS_INFRAHUBCLIENT:
             if not related_node:
                 node_attr.fetch()
                 related_node = node_attr.peer
+                if related_node is not None and related_node.id:
+                    self._fully_fetched_peer_ids.add(related_node.id)
 
             if not related_node:
                 return None

--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -598,6 +598,9 @@ if HAS_INFRAHUBCLIENT:
         ):
             self.client = client
             self.display = display
+            # Peer ids already refetched by _peer_needs_concrete_refetch, so a
+            # genuinely empty relationship doesn't refetch once per host node.
+            self._refetched_peer_ids: set[str] = set()
 
         def _handle_display(
             self, message: str, exception: Exception | None = None, level: str | None = "ERROR"
@@ -673,6 +676,25 @@ if HAS_INFRAHUBCLIENT:
             tmp_attr = getattr(refetch_cache["node"], root_attr, None)
             return str(tmp_attr.value) if tmp_attr.value else tmp_attr.value
 
+        def _peer_needs_concrete_refetch(self, related_node: InfrahubNodeSync, nested_attrs: list[str]) -> bool:
+            """Whether a store-cached peer must be refetched by its concrete kind (#384).
+
+            A peer reached through a relationship declared against a generic is cached
+            typed by its concrete kind (from ``__typename``) but only carries the
+            generic's fields: a requested concrete-only relationship then exists on
+            the schema yet holds no id, and the nested traversal would silently
+            resolve empty. Refetched ids are remembered so a genuinely empty
+            relationship doesn't trigger a refetch for every host traversing it.
+            """
+            if related_node.id in self._refetched_peer_ids:
+                return False
+            for root_attr in {attr.split(".", 1)[0] for attr in nested_attrs}:
+                node_attr = getattr(related_node, root_attr, None)
+                if isinstance(node_attr, RelatedNodeSync) and node_attr.id is None:
+                    self._refetched_peer_ids.add(related_node.id)
+                    return True
+            return False
+
         def _resolve_many_relationship(
             self, node_attr: RelationshipManagerSync, nested_attrs: list[str], has_nested: bool, schemas: dict[str, Any]
         ) -> list[Any]:
@@ -688,6 +710,8 @@ if HAS_INFRAHUBCLIENT:
 
             for peer in node_attr.peers:
                 related_node = store.get(key=peer.id, raise_when_missing=False)
+                if related_node and has_nested and self._peer_needs_concrete_refetch(related_node, nested_attrs):
+                    related_node = None
                 if not related_node:
                     peer.fetch()
                     related_node = peer.peer
@@ -717,6 +741,8 @@ if HAS_INFRAHUBCLIENT:
 
             store = self.client.client.store
             related_node = store.get(key=node_attr.id, raise_when_missing=False)
+            if related_node and has_nested and self._peer_needs_concrete_refetch(related_node, nested_attrs):
+                related_node = None
             if not related_node:
                 node_attr.fetch()
                 related_node = node_attr.peer

--- a/tests/integration/processor/test_generic_peer_traversal.py
+++ b/tests/integration/processor/test_generic_peer_traversal.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026 Opsmill
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Regression test for issue #384: nested traversal through a generic peer.
+
+When a relationship's declared peer is a generic, the SDK caches the peer typed
+by its concrete kind (``__typename``) but shaped by the generic's fields, so a
+concrete-only relationship (``parent``) used to resolve empty from the store.
+
+Schema shape (mirrors the issue):
+  - TestingLocationGeneric (generic) — has neither ``name`` nor ``parent``
+  - TestingSite (inherits the generic) — has ``name`` and ``parent`` -> TestingRegion
+  - TestingDevice.site — declared peer is the *generic*
+
+Expectation under test: ``site.parent.name`` resolves, identically with
+``prefetch_relationships`` True and False.
+
+Run:
+  INFRAHUB_TESTING_IMAGE_VER=1.10.5 uv run --no-group dev --group integration \
+      pytest tests/integration/processor/test_generic_peer_traversal.py -m integration
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("infrahub_testcontainers")
+
+from ansible_collections.opsmill.infrahub.plugins.module_utils import infrahub_utils as iu
+from infrahub_sdk import Config, InfrahubClientSync
+from infrahub_sdk.schema.main import (
+    AttributeKind,
+    GenericSchema,
+    NodeSchema,
+    RelationshipKind,
+    SchemaRoot,
+)
+from infrahub_sdk.schema.main import AttributeSchema as Attr
+from infrahub_sdk.schema.main import RelationshipSchema as Rel
+from infrahub_sdk.testing.docker import TestInfrahubDockerClient
+from infrahub_testcontainers.container import PROJECT_ENV_VARIABLES
+
+pytestmark = pytest.mark.integration
+
+ADMIN_TOKEN = PROJECT_ENV_VARIABLES["INFRAHUB_TESTING_INITIAL_ADMIN_TOKEN"]
+
+NAMESPACE = "Testing"
+LOCATION_GENERIC = f"{NAMESPACE}LocationGeneric"
+SITE = f"{NAMESPACE}Site"
+REGION = f"{NAMESPACE}Region"
+DEVICE = f"{NAMESPACE}Device"
+
+
+def build_schema() -> SchemaRoot:
+    location_generic = GenericSchema(
+        name="LocationGeneric",
+        namespace=NAMESPACE,
+        display_labels=["description__value"],
+        attributes=[Attr(name="description", kind=AttributeKind.TEXT, optional=True)],
+    )
+    region = NodeSchema(
+        name="Region",
+        namespace=NAMESPACE,
+        default_filter="name__value",
+        human_friendly_id=["name__value"],
+        display_labels=["name__value"],
+        attributes=[Attr(name="name", kind=AttributeKind.TEXT, unique=True)],
+    )
+    site = NodeSchema(
+        name="Site",
+        namespace=NAMESPACE,
+        inherit_from=[LOCATION_GENERIC],
+        default_filter="name__value",
+        human_friendly_id=["name__value"],
+        display_labels=["name__value"],
+        attributes=[Attr(name="name", kind=AttributeKind.TEXT, unique=True)],
+        relationships=[
+            Rel(name="parent", peer=REGION, kind=RelationshipKind.ATTRIBUTE, cardinality="one", optional=False),
+        ],
+    )
+    device = NodeSchema(
+        name="Device",
+        namespace=NAMESPACE,
+        default_filter="name__value",
+        human_friendly_id=["name__value"],
+        display_labels=["name__value"],
+        attributes=[Attr(name="name", kind=AttributeKind.TEXT, unique=True)],
+        relationships=[
+            Rel(name="site", peer=LOCATION_GENERIC, kind=RelationshipKind.ATTRIBUTE, cardinality="one", optional=False),
+        ],
+    )
+    return SchemaRoot(version="1.0", generics=[location_generic], nodes=[region, site, device])
+
+
+class TestIssue384GenericPeerTraversal(TestInfrahubDockerClient):
+    @pytest.fixture(scope="class")
+    def dataset(self, client_sync: InfrahubClientSync) -> None:
+        resp = client_sync.schema.load(schemas=[build_schema().to_schema_dict()], wait_until_converged=True)
+        if resp.errors:
+            raise RuntimeError(f"schema load failed: {resp.errors}")
+
+        region = client_sync.create(kind=REGION, name="region-1")
+        region.save()
+        site = client_sync.create(kind=SITE, name="site-a", parent=region)
+        site.save()
+        device = client_sync.create(kind=DEVICE, name="device-01", site=site)
+        device.save()
+
+    def _fresh_processor(self, infrahub_port: int) -> iu.InfrahubNodesProcessor:
+        """A processor with its own client/store, like each real ansible-inventory run."""
+        wrapper = iu.InfrahubclientWrapper.__new__(iu.InfrahubclientWrapper)
+        wrapper.client = InfrahubClientSync(
+            address=f"http://localhost:{infrahub_port}",
+            config=Config(api_token=ADMIN_TOKEN, timeout=60),
+        )
+        return iu.InfrahubNodesProcessor(client=wrapper)
+
+    @pytest.mark.parametrize("prefetch", [False, True], ids=["prefetch-off", "prefetch-on"])
+    def test_nested_traversal_through_generic_peer(self, infrahub_port: int, dataset: None, prefetch: bool) -> None:
+        processor = self._fresh_processor(infrahub_port)
+
+        result = processor.fetch_and_process(
+            nodes={DEVICE: {"include": ["name", "site.name", "site.parent.name"]}},
+            prefetch_relationships=prefetch,
+        )
+
+        assert result is not None
+        assert len(result) == 1
+        attrs = next(iter(result.values()))
+
+        assert attrs["name"] == "device-01"
+        assert attrs["site"]["name"] == "site-a"
+        assert attrs["site"]["parent"].get("name") == "region-1"

--- a/tests/unit/plugins/module_utils/test_generic_peer_refetch.py
+++ b/tests/unit/plugins/module_utils/test_generic_peer_refetch.py
@@ -79,3 +79,16 @@ def test_genuinely_empty_relationship_refetches_only_once(mocker):
     processor._resolve_one_relationship(node_attr, ["parent.name"], has_nested=True, schemas={})
 
     node_attr.fetch.assert_called_once()
+
+
+def test_failed_refetch_is_retried_by_later_hosts(mocker):
+    """A refetch that yields no usable peer is not memoized, so the next host retries it."""
+    cached = _cached_peer(mocker, nested_rel_id=None)
+    processor = _make_processor(mocker, cached)
+    node_attr = _one_rel(mocker, fresh_peer=None)
+    mocker.patch.object(processor, "resolve_node_mapping", return_value={})
+
+    assert processor._resolve_one_relationship(node_attr, ["parent.name"], has_nested=True, schemas={}) is None
+    processor._resolve_one_relationship(node_attr, ["parent.name"], has_nested=True, schemas={})
+
+    assert node_attr.fetch.call_count == 2

--- a/tests/unit/plugins/module_utils/test_generic_peer_refetch.py
+++ b/tests/unit/plugins/module_utils/test_generic_peer_refetch.py
@@ -1,0 +1,81 @@
+"""Unit tests for the concrete-kind refetch of store-cached peers (issue #384).
+
+A peer reached through a relationship declared against a generic is cached in
+the SDK store typed by its concrete kind (from ``__typename``) but only carries
+the generic's fields. A requested nested relationship then exists on the schema
+yet holds no id, and the traversal silently resolved empty. The resolver must
+detect that and refetch the peer by its concrete kind instead.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from ansible_collections.opsmill.infrahub.plugins.module_utils import infrahub_utils as iu
+
+
+def _make_processor(mocker, cached_peer):
+    client = mocker.MagicMock()
+    client.store.get.return_value = cached_peer
+    wrapper = mocker.MagicMock()
+    wrapper.client = client
+    return iu.InfrahubNodesProcessor(client=wrapper)
+
+
+def _cached_peer(mocker, peer_id="site-1", nested_rel_id=None):
+    """A store-cached peer whose ``parent`` relationship is a RelatedNodeSync with the given id."""
+    nested_rel = mocker.MagicMock(spec=iu.RelatedNodeSync)
+    nested_rel.id = nested_rel_id
+    return SimpleNamespace(id=peer_id, parent=nested_rel)
+
+
+def _one_rel(mocker, peer_id="site-1", fresh_peer=None):
+    """A host node's one-cardinality relationship pointing at the cached peer."""
+    node_attr = mocker.MagicMock(spec=iu.RelatedNodeSync)
+    node_attr.id = peer_id
+    node_attr.schema = SimpleNamespace(peer="LocationGeneric")
+    node_attr.peer = fresh_peer
+    return node_attr
+
+
+def test_store_hit_with_uninitialized_nested_relationship_refetches_peer(mocker):
+    """A cached peer missing data for a requested nested relationship is refetched."""
+    cached = _cached_peer(mocker, nested_rel_id=None)
+    fresh = SimpleNamespace(id="site-1")
+    processor = _make_processor(mocker, cached)
+    node_attr = _one_rel(mocker, fresh_peer=fresh)
+    resolve = mocker.patch.object(processor, "resolve_node_mapping", return_value={"parent": {"name": "region-1"}})
+
+    result = processor._resolve_one_relationship(node_attr, ["parent.name"], has_nested=True, schemas={})
+
+    node_attr.fetch.assert_called_once()
+    # Nested resolution ran against the refetched peer, not the incomplete cached copy.
+    assert resolve.call_args.kwargs["node"] is fresh
+    assert result == {"parent": {"name": "region-1"}}
+
+
+def test_store_hit_with_complete_nested_relationship_uses_cache(mocker):
+    """A cached peer that already has the nested relationship id is used as-is."""
+    cached = _cached_peer(mocker, nested_rel_id="region-uuid")
+    processor = _make_processor(mocker, cached)
+    node_attr = _one_rel(mocker)
+    resolve = mocker.patch.object(processor, "resolve_node_mapping", return_value={"parent": {"name": "region-1"}})
+
+    processor._resolve_one_relationship(node_attr, ["parent.name"], has_nested=True, schemas={})
+
+    node_attr.fetch.assert_not_called()
+    assert resolve.call_args.kwargs["node"] is cached
+
+
+def test_genuinely_empty_relationship_refetches_only_once(mocker):
+    """A peer whose relationship is empty even after refetch is not refetched per host."""
+    cached = _cached_peer(mocker, nested_rel_id=None)
+    processor = _make_processor(mocker, cached)
+    # The refetch returns the same shape (the relationship is genuinely empty).
+    node_attr = _one_rel(mocker, fresh_peer=cached)
+    mocker.patch.object(processor, "resolve_node_mapping", return_value={"parent": {}})
+
+    processor._resolve_one_relationship(node_attr, ["parent.name"], has_nested=True, schemas={})
+    processor._resolve_one_relationship(node_attr, ["parent.name"], has_nested=True, schemas={})
+
+    node_attr.fetch.assert_called_once()


### PR DESCRIPTION
Fixes #384

## Problem

When a relationship's declared peer is a **generic** and the concrete peer kind has fields the generic does not (e.g. `Device.site` -> `LocationGeneric`, while the actual peer `LocationSite` has `parent` -> `LocationRegion`), a nested inventory traversal such as `site.parent.name` silently resolves to `{}`. With `strict: true` plus `keyed_groups`/`compose` built on that path, the whole inventory run aborts.

Reproduced against a live Infrahub 1.10.5 (via `infrahub-testcontainers`): on `develop` the traversal resolved empty with `prefetch_relationships` **both** `true` and `false` (the issue reports it for `true` on v1.7.0; there `false` only worked by accident, via store misses falling back to per-peer fetches — hence the 87s vs 40s timings in the report).

## Root cause

1. The SDK builds peer sub-queries (and top-level queries for a generic kind) from the **declared peer schema** — the generic — and the collection never requests fragments, so concrete-only fields are absent from the GraphQL response.
2. `InfrahubNodeSync.from_graphql` types the peer by `__typename`, so the SDK store ends up holding a node that *claims* to be the concrete kind (its schema has `parent`) but was built from generic-shaped data: its `parent` relationship holds no id.
3. The store is last-write-wins by node id, and `fetch_and_process`'s bulk prefetch of the declared peer kind (the generic) guarantees such an entry lands there in both prefetch modes.
4. `_resolve_one_relationship` / `_resolve_many_relationship` hit the store and never refetch, so the nested traversal resolves `{}`. The store-*miss* path (`RelatedNodeSync.fetch()`) fetches by the concrete `typename` and resolves correctly — schema attributes already had a refetch fallback (`_resolve_schema_attribute`), relationships had none.

## Fix

Add a relationship-level analogue of the existing attribute refetch fallback: before resolving nested attributes from a store-cached peer, check whether any requested one-cardinality relationship exists on the peer's schema but holds no id (the generic-shaped-data signature). If so, refetch the peer once by its concrete kind via the existing store-miss path (which also repairs the store entry for subsequent hosts). Refetched ids are remembered per processor run so a genuinely empty relationship doesn't trigger a refetch for every host traversing it.

Many-cardinality nested relationships already self-heal (`RelationshipManagerSync.fetch()` when uninitialized), so only the one-cardinality case needed the guard.

## Tests

- `tests/unit/plugins/module_utils/test_generic_peer_refetch.py` — unit coverage: incomplete cached peer is refetched and resolution uses the fresh node; complete cached peer is used as-is; genuinely empty relationship refetches only once.
- `tests/integration/processor/test_generic_peer_traversal.py` — live regression test (testcontainers) modeling the issue's schema (generic peer without `name`/`parent`, concrete `Site` with `parent` -> `Region`), asserting `site.parent.name` resolves identically with `prefetch_relationships` true and false. Failed on `develop`, passes with the fix:

```
INFRAHUB_TESTING_IMAGE_VER=1.10.5 uv run --no-group dev --group integration \
    pytest tests/integration/processor/test_generic_peer_traversal.py -m integration
```

- `invoke format` / `invoke lint` clean, `ansible-test sanity` clean, all unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nested inventory traversal through generic-declared peers that returned empty maps and could abort runs. Previously, nested paths like site.parent.name resolved to {} from a cached generic-shaped peer; now the processor refetches once by concrete kind and memoizes only successful fetches, ensuring consistent results with `prefetch_relationships` on or off and allowing retries after failures.

- Adds `_peer_needs_concrete_refetch` and per-run memo `_fully_fetched_peer_ids`; applies the guard in one- and many-cardinality paths and records ids only after a usable full fetch, so genuine empties refetch once while failed refetches are retried by later hosts.
- Adds unit and integration tests reproducing the generic peer schema and asserting identical traversal with `prefetch_relationships` true/false; covers cache use, single refetch for genuine empties, and retry on failed refetch. No configuration or migration changes.

<sup>Written for commit 1a33acf1a9373f3b4df750f66bb9b31d7c2bd070. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-ansible/pull/386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

