### PR TITLE
fix(lookup): surface the real cause when a GraphQL query fails

### DIFF
--- a/plugins/module_utils/exception.py
+++ b/plugins/module_utils/exception.py
@@ -48,7 +48,7 @@ def _handle_exc(
     elif exc.__class__ == BranchNotFoundError:
         raise exc
     else:
-        raise Exception(exc)
+        raise Exception(exc) from exc
 
 
 def handle_infrahub_exceptions_decorator(display: Display | None) -> Callable[[Callable], Callable]:

--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -1698,11 +1698,13 @@ if HAS_INFRAHUBCLIENT:
                 # Not an empty result set: `handle_infrahub_exceptions` logs and returns
                 # None rather than raising whenever a Display is attached, which every
                 # plugin does. So a failed call arrives here as nothing at all, with the
-                # reason already emitted as a warning -- point at it instead of blaming
+                # reason already reported above -- as a warning for most failures, but
+                # through `display.error` when the server was unreachable or
+                # unresponsive. Point at it without naming a level, instead of blaming
                 # the query.
                 raise Exception(
                     "Failed to execute the GraphQL query: no response was returned. "
-                    "The reason was reported as a warning above; re-run with -vvv for the full error."
+                    "The reason was reported above; re-run with -vvv for the full error."
                 )
 
             if any(key.endswith(("Create", "Update", "Delete")) for key in response):

--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -1664,14 +1664,27 @@ if HAS_INFRAHUBCLIENT:
             else:
                 raise Exception("query is neither a string nor a dict")
 
+            results = {}
             try:
-                results = {}
                 response = self.client.execute_graphql(query=query_str, variables=variables)
-                if not response:
-                    raise Exception
+            except Exception as exc:
+                # Name the cause and chain it. The lookup plugin re-raises whatever
+                # comes out of here as `AnsibleError(str(exc))`, so a message built
+                # only from the query text is the entirety of what a playbook author
+                # sees -- the status code, the GraphQL error list or the timeout that
+                # explains the failure never reached them.
+                raise Exception(f"Failed to execute the GraphQL query: {type(exc).__name__}: {exc}") from exc
 
-            except Exception:
-                raise Exception(f"Failed to execute the grapqhl query '{query}'")
+            if not response:
+                # Not an empty result set: `handle_infrahub_exceptions` logs and returns
+                # None rather than raising whenever a Display is attached, which every
+                # plugin does. So a failed call arrives here as nothing at all, with the
+                # reason already emitted as a warning -- point at it instead of blaming
+                # the query.
+                raise Exception(
+                    "Failed to execute the GraphQL query: no response was returned. "
+                    "The reason was reported as a warning above; re-run with -vvv for the full error."
+                )
 
             if any(key.endswith(("Create", "Update", "Delete")) for key in response):
                 # Handle mutation response

--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -1697,14 +1697,17 @@ if HAS_INFRAHUBCLIENT:
             if not response:
                 # Not an empty result set: `handle_infrahub_exceptions` logs and returns
                 # None rather than raising whenever a Display is attached, which every
-                # plugin does. So a failed call arrives here as nothing at all, with the
-                # reason already reported above -- as a warning for most failures, but
-                # through `display.error` when the server was unreachable or
-                # unresponsive. Point at it without naming a level, instead of blaming
-                # the query.
+                # plugin does. So a failed call arrives here as nothing at all, and what
+                # reached the operator is a single line -- a warning for most failures,
+                # but `display.error` when the server was unreachable or unresponsive.
+                # That line only carries the reason on the `GraphQLError` path; the
+                # others keep it behind `display.verbose(..., caplevel=2)`, so -vvv.
+                # Point at both, instead of blaming the query or promising a reason that
+                # may not be on screen.
                 raise Exception(
-                    "Failed to execute the GraphQL query: no response was returned. "
-                    "The reason was reported above; re-run with -vvv for the full error."
+                    "Failed to execute the GraphQL query: the call returned no response. "
+                    "A line was logged above -- a warning, or an error when the server was "
+                    "unreachable or unresponsive -- re-run with -vvv to see the reason itself."
                 )
 
             if any(key.endswith(("Create", "Update", "Delete")) for key in response):

--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -76,6 +76,22 @@ TEXT_MIME_TYPES = frozenset(
     }
 )
 
+
+def unwrap_wrapped_error(exc: BaseException) -> BaseException:
+    """Return the SDK error that `handle_infrahub_exceptions` replaced with a bare `Exception`.
+
+    `InfrahubclientWrapper.__init__` wraps every one of its public methods in that
+    decorator, and with no `Display` attached the decorator re-raises the original as
+    `Exception(exc)`. A caller that formats the exception it caught would therefore
+    report the type as "Exception" -- which names nothing -- and chain to the stand-in
+    rather than to the GraphQL, HTTP or timeout error that explains the failure. The
+    original is the stand-in's only argument, so hand that back instead.
+    """
+    if exc.__class__ is Exception and len(exc.args) == 1 and isinstance(exc.args[0], BaseException):
+        return exc.args[0]
+    return exc
+
+
 if HAS_INFRAHUBCLIENT:
     TYPE_MAPPING = {"str": str, "int": int, "float": float, "bool": bool}
 
@@ -1672,8 +1688,11 @@ if HAS_INFRAHUBCLIENT:
                 # comes out of here as `AnsibleError(str(exc))`, so a message built
                 # only from the query text is the entirety of what a playbook author
                 # sees -- the status code, the GraphQL error list or the timeout that
-                # explains the failure never reached them.
-                raise Exception(f"Failed to execute the GraphQL query: {type(exc).__name__}: {exc}") from exc
+                # explains the failure never reached them. Unwrap first: the client
+                # wrapper's exception decorator hands us the SDK error boxed in a bare
+                # `Exception`, and naming that box reports the type as "Exception".
+                cause = unwrap_wrapped_error(exc)
+                raise Exception(f"Failed to execute the GraphQL query: {type(cause).__name__}: {cause}") from cause
 
             if not response:
                 # Not an empty result set: `handle_infrahub_exceptions` logs and returns

--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -1684,13 +1684,19 @@ if HAS_INFRAHUBCLIENT:
             try:
                 response = self.client.execute_graphql(query=query_str, variables=variables)
             except Exception as exc:
-                # Name the cause and chain it. The lookup plugin re-raises whatever
-                # comes out of here as `AnsibleError(str(exc))`, so a message built
-                # only from the query text is the entirety of what a playbook author
-                # sees -- the status code, the GraphQL error list or the timeout that
-                # explains the failure never reached them. Unwrap first: the client
-                # wrapper's exception decorator hands us the SDK error boxed in a bare
-                # `Exception`, and naming that box reports the type as "Exception".
+                # Defensive: the client wrapper's exception decorator only re-raises for
+                # a caller that built the wrapper without a Display. Both shipped plugins
+                # pass one, so their failures are logged, come back as None, and land in
+                # the `if not response:` branch below rather than here.
+                #
+                # For the callers that do reach here, name the cause and chain it. The
+                # lookup plugin re-raises whatever comes out of here as
+                # `AnsibleError(str(exc))`, so a message built only from the query text is
+                # the entirety of what a playbook author sees -- the status code, the
+                # GraphQL error list or the timeout that explains the failure never
+                # reached them. Unwrap first: the decorator hands a Display-less caller
+                # the SDK error boxed in a bare `Exception`, and naming that box reports
+                # the type as "Exception".
                 cause = unwrap_wrapped_error(exc)
                 raise Exception(f"Failed to execute the GraphQL query: {type(cause).__name__}: {cause}") from cause
 

--- a/tests/unit/plugins/module_utils/test_query_processor_errors.py
+++ b/tests/unit/plugins/module_utils/test_query_processor_errors.py
@@ -117,9 +117,10 @@ def test_decorated_unexpected_error_keeps_its_own_type_and_cause():
 def test_empty_response_says_the_call_failed_not_that_the_query_is_bad(mocker):
     """``None`` back means the decorator swallowed a failure, and the message says so.
 
-    ``handle_infrahub_exceptions`` turns a ``GraphQLError`` into ``display.warning``
-    and returns ``None`` whenever a ``Display`` is attached. Reporting that as a bad
-    query sent people looking at their query text for a server-side problem.
+    ``handle_infrahub_exceptions`` logs and returns ``None`` whenever a ``Display`` is
+    attached. Reporting that as a bad query sent people looking at their query text for
+    a server-side problem. The message names the line that was logged and where the
+    reason lives, without claiming the reason itself is already on screen.
     """
     processor = _processor(mocker, return_value=None)
 
@@ -128,13 +129,20 @@ def test_empty_response_says_the_call_failed_not_that_the_query_is_bad(mocker):
 
     message = str(excinfo.value)
     assert "no response" in message.lower()
-    # Points at where the detail actually is, rather than echoing the query back.
-    assert "reported above" in message.lower()
+    # Points at the line the decorator logged, rather than echoing the query back.
+    assert "logged above" in message.lower()
     assert RENDERED not in message
-    # The level is deliberately unnamed: `handle_infrahub_exceptions` reports an
-    # unreachable or unresponsive server through ``display.error``, so promising a
-    # warning would send those authors looking for a line that was never logged.
-    assert "warning" not in message.lower()
+    # Both levels are named: `handle_infrahub_exceptions` reports an unreachable or
+    # unresponsive server through ``display.error`` and everything else through
+    # ``display.warning``, so naming only one sends half the authors looking for a
+    # line that was never logged.
+    assert "warning" in message.lower()
+    assert "error" in message.lower()
+    # Outside the ``GraphQLError`` path that logged line is only a generic prefix --
+    # the reason sits behind ``display.verbose(..., caplevel=2)``. So the message
+    # routes people to -vvv instead of claiming the reason was already printed.
+    assert "-vvv" in message
+    assert "reported above" not in message.lower()
 
 
 def test_typo_free_message(mocker):

--- a/tests/unit/plugins/module_utils/test_query_processor_errors.py
+++ b/tests/unit/plugins/module_utils/test_query_processor_errors.py
@@ -12,7 +12,8 @@ Two distinct failures reach this code, and they need different messages:
 * ``execute_graphql`` raised -- the cause is the exception.
 * ``execute_graphql`` returned ``None`` -- the wrapper's exception decorator logs and
   swallows whenever a ``Display`` is attached, which every plugin does, so a failed
-  call arrives here as an empty return with the detail already in a warning.
+  call arrives here as an empty return with the detail already reported -- as a
+  warning for most failures, as an error for an unreachable or unresponsive server.
 """
 
 from __future__ import annotations
@@ -128,7 +129,12 @@ def test_empty_response_says_the_call_failed_not_that_the_query_is_bad(mocker):
     message = str(excinfo.value)
     assert "no response" in message.lower()
     # Points at where the detail actually is, rather than echoing the query back.
-    assert "warning" in message.lower()
+    assert "reported above" in message.lower()
+    assert RENDERED not in message
+    # The level is deliberately unnamed: `handle_infrahub_exceptions` reports an
+    # unreachable or unresponsive server through ``display.error``, so promising a
+    # warning would send those authors looking for a line that was never logged.
+    assert "warning" not in message.lower()
 
 
 def test_typo_free_message(mocker):

--- a/tests/unit/plugins/module_utils/test_query_processor_errors.py
+++ b/tests/unit/plugins/module_utils/test_query_processor_errors.py
@@ -19,18 +19,43 @@ from __future__ import annotations
 
 import pytest
 from ansible_collections.opsmill.infrahub.plugins.module_utils import infrahub_utils as iu
+from ansible_collections.opsmill.infrahub.plugins.module_utils.exception import handle_infrahub_exceptions_decorator
+from infrahub_sdk.exceptions import GraphQLError
 
 QUERY = {"ZoneBNG": {"edges": {"node": {"name": {"value": None}}}}}
+RENDERED = "query { ZoneBNG { edges { node { name { value } } } } }"
 
 
 def _processor(mocker, *, side_effect=None, return_value=None):
     """A query processor whose ``execute_graphql`` behaves as the test asks."""
     wrapper = mocker.MagicMock()
-    wrapper._render_query.return_value = "query { ZoneBNG { edges { node { name { value } } } } }"
+    wrapper._render_query.return_value = RENDERED
     wrapper.execute_graphql.side_effect = side_effect
     if side_effect is None:
         wrapper.execute_graphql.return_value = return_value
     return iu.InfrahubQueryProcessor(client=wrapper)
+
+
+def _decorated_processor(error):
+    """A query processor whose client is decorated the way the real wrapper decorates itself.
+
+    A ``MagicMock`` raises whatever the test hands it, which is exactly what the
+    production wrapper never does: ``InfrahubclientWrapper.__init__`` runs every
+    public method through ``handle_infrahub_exceptions_decorator``, so the caller
+    sees the decorator's output, not the SDK's. These tests reproduce that
+    decoration rather than mocking past it.
+    """
+
+    class _Client:
+        def _render_query(self, query, variables=None):
+            return RENDERED
+
+        def execute_graphql(self, query, variables=None, branch=None):
+            raise error
+
+    client = _Client()
+    client.execute_graphql = handle_infrahub_exceptions_decorator(None)(client.execute_graphql)
+    return iu.InfrahubQueryProcessor(client=client)
 
 
 def test_raised_failure_keeps_its_cause_and_message(mocker):
@@ -51,6 +76,41 @@ def test_raised_failure_keeps_its_cause_and_message(mocker):
     # And it is legible without a traceback, which is all AnsibleError(str(exc)) shows.
     assert "Server returned HTTP 502" in str(excinfo.value)
     assert "RuntimeError" in str(excinfo.value)
+
+
+def test_decorated_graphql_error_is_named_not_the_wrapper_stand_in():
+    """Through the real decorator, the reported type is ``GraphQLError``, not ``Exception``.
+
+    With no ``Display`` attached the decorator re-raises the SDK error as a bare
+    ``Exception(exc)``. Formatting that directly reported the type as "Exception" and
+    chained ``__cause__`` to the stand-in, leaving the real error one level further
+    away than the message and the traceback both claimed.
+    """
+    original = GraphQLError(errors=[{"message": "Zone 'bng' does not exist"}])
+    processor = _decorated_processor(original)
+
+    with pytest.raises(Exception) as excinfo:
+        processor.fetch_and_process(query=QUERY)
+
+    message = str(excinfo.value)
+    assert "GraphQLError" in message
+    assert "Zone 'bng' does not exist" in message
+    assert "query: Exception:" not in message
+    assert excinfo.value.__cause__ is original
+
+
+def test_decorated_unexpected_error_keeps_its_own_type_and_cause():
+    """The same holds for the decorator's catch-all branch, which goes through ``_handle_exc``."""
+    original = RuntimeError("Server returned HTTP 502")
+    processor = _decorated_processor(original)
+
+    with pytest.raises(Exception) as excinfo:
+        processor.fetch_and_process(query=QUERY)
+
+    message = str(excinfo.value)
+    assert "RuntimeError" in message
+    assert "Server returned HTTP 502" in message
+    assert excinfo.value.__cause__ is original
 
 
 def test_empty_response_says_the_call_failed_not_that_the_query_is_bad(mocker):

--- a/tests/unit/plugins/module_utils/test_query_processor_errors.py
+++ b/tests/unit/plugins/module_utils/test_query_processor_errors.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026 Opsmill
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""What ``InfrahubQueryProcessor.fetch_and_process`` says when a query does not work.
+
+This is the lookup plugin's only error surface: ``lookup.py`` catches whatever comes
+out of here and re-raises it as ``AnsibleError(str(exc))``, so a message that names
+only the query is the whole of what a playbook author sees.
+
+Two distinct failures reach this code, and they need different messages:
+
+* ``execute_graphql`` raised -- the cause is the exception.
+* ``execute_graphql`` returned ``None`` -- the wrapper's exception decorator logs and
+  swallows whenever a ``Display`` is attached, which every plugin does, so a failed
+  call arrives here as an empty return with the detail already in a warning.
+"""
+
+from __future__ import annotations
+
+import pytest
+from ansible_collections.opsmill.infrahub.plugins.module_utils import infrahub_utils as iu
+
+QUERY = {"ZoneBNG": {"edges": {"node": {"name": {"value": None}}}}}
+
+
+def _processor(mocker, *, side_effect=None, return_value=None):
+    """A query processor whose ``execute_graphql`` behaves as the test asks."""
+    wrapper = mocker.MagicMock()
+    wrapper._render_query.return_value = "query { ZoneBNG { edges { node { name { value } } } } }"
+    wrapper.execute_graphql.side_effect = side_effect
+    if side_effect is None:
+        wrapper.execute_graphql.return_value = return_value
+    return iu.InfrahubQueryProcessor(client=wrapper)
+
+
+def test_raised_failure_keeps_its_cause_and_message(mocker):
+    """A GraphQL/transport failure survives to the caller instead of being replaced.
+
+    The old code caught bare ``Exception`` and re-raised a message built only from the
+    query, so the status code, the GraphQL error list or the timeout that actually
+    explained the failure never reached the playbook.
+    """
+    original = RuntimeError("Server returned HTTP 502")
+    processor = _processor(mocker, side_effect=original)
+
+    with pytest.raises(Exception) as excinfo:
+        processor.fetch_and_process(query=QUERY)
+
+    # The cause is chained, so `-vvv` and any traceback still reach the real error.
+    assert excinfo.value.__cause__ is original
+    # And it is legible without a traceback, which is all AnsibleError(str(exc)) shows.
+    assert "Server returned HTTP 502" in str(excinfo.value)
+    assert "RuntimeError" in str(excinfo.value)
+
+
+def test_empty_response_says_the_call_failed_not_that_the_query_is_bad(mocker):
+    """``None`` back means the decorator swallowed a failure, and the message says so.
+
+    ``handle_infrahub_exceptions`` turns a ``GraphQLError`` into ``display.warning``
+    and returns ``None`` whenever a ``Display`` is attached. Reporting that as a bad
+    query sent people looking at their query text for a server-side problem.
+    """
+    processor = _processor(mocker, return_value=None)
+
+    with pytest.raises(Exception) as excinfo:
+        processor.fetch_and_process(query=QUERY)
+
+    message = str(excinfo.value)
+    assert "no response" in message.lower()
+    # Points at where the detail actually is, rather than echoing the query back.
+    assert "warning" in message.lower()
+
+
+def test_typo_free_message(mocker):
+    """The word is "GraphQL". Pinned because the old message shipped `grapqhl`."""
+    processor = _processor(mocker, side_effect=RuntimeError("boom"))
+
+    with pytest.raises(Exception) as excinfo:
+        processor.fetch_and_process(query=QUERY)
+
+    assert "grapqhl" not in str(excinfo.value)
+
+
+def test_successful_query_is_returned_unchanged(mocker):
+    """The happy path is untouched: a query response comes back as-is."""
+    payload = {"ZoneBNG": {"edges": [{"node": {"name": {"value": "bng-01"}}}]}}
+    processor = _processor(mocker, return_value=payload)
+
+    assert processor.fetch_and_process(query=QUERY) == payload

--- a/tests/unit/plugins/module_utils/test_query_processor_errors.py
+++ b/tests/unit/plugins/module_utils/test_query_processor_errors.py
@@ -12,8 +12,13 @@ Two distinct failures reach this code, and they need different messages:
 * ``execute_graphql`` raised -- the cause is the exception.
 * ``execute_graphql`` returned ``None`` -- the wrapper's exception decorator logs and
   swallows whenever a ``Display`` is attached, which every plugin does, so a failed
-  call arrives here as an empty return with the detail already reported -- as a
-  warning for most failures, as an error for an unreachable or unresponsive server.
+  call arrives here as an empty return, with one line already logged: a warning for
+  most failures, an error for an unreachable or unresponsive server, and the reason
+  itself on that line only on the ``GraphQLError`` path.
+
+The second is the one the shipped plugins take -- ``lookup.py`` and ``query_graphql.py``
+both attach a ``Display`` -- so it is tested through the real decorator rather than
+through a mock that raises where production never does.
 """
 
 from __future__ import annotations
@@ -21,7 +26,7 @@ from __future__ import annotations
 import pytest
 from ansible_collections.opsmill.infrahub.plugins.module_utils import infrahub_utils as iu
 from ansible_collections.opsmill.infrahub.plugins.module_utils.exception import handle_infrahub_exceptions_decorator
-from infrahub_sdk.exceptions import GraphQLError
+from infrahub_sdk.exceptions import GraphQLError, ServerNotResponsiveError
 
 QUERY = {"ZoneBNG": {"edges": {"node": {"name": {"value": None}}}}}
 RENDERED = "query { ZoneBNG { edges { node { name { value } } } } }"
@@ -37,7 +42,7 @@ def _processor(mocker, *, side_effect=None, return_value=None):
     return iu.InfrahubQueryProcessor(client=wrapper)
 
 
-def _decorated_processor(error):
+def _decorated_processor(error, display=None):
     """A query processor whose client is decorated the way the real wrapper decorates itself.
 
     A ``MagicMock`` raises whatever the test hands it, which is exactly what the
@@ -45,6 +50,11 @@ def _decorated_processor(error):
     public method through ``handle_infrahub_exceptions_decorator``, so the caller
     sees the decorator's output, not the SDK's. These tests reproduce that
     decoration rather than mocking past it.
+
+    ``display`` picks which half of the decorator runs, and the two halves reach this
+    code by different doors: with nothing attached it re-raises, so the failure arrives
+    as an exception; with a ``Display`` attached it logs and returns ``None``, so the
+    failure arrives as an empty response.
     """
 
     class _Client:
@@ -55,7 +65,7 @@ def _decorated_processor(error):
             raise error
 
     client = _Client()
-    client.execute_graphql = handle_infrahub_exceptions_decorator(None)(client.execute_graphql)
+    client.execute_graphql = handle_infrahub_exceptions_decorator(display)(client.execute_graphql)
     return iu.InfrahubQueryProcessor(client=client)
 
 
@@ -143,6 +153,70 @@ def test_empty_response_says_the_call_failed_not_that_the_query_is_bad(mocker):
     # routes people to -vvv instead of claiming the reason was already printed.
     assert "-vvv" in message
     assert "reported above" not in message.lower()
+
+
+def test_display_attached_failure_arrives_as_an_empty_response(mocker):
+    """The path the shipped plugins actually take, pinned through the real decorator.
+
+    ``lookup.py`` and ``query_graphql.py`` both build their wrapper with ``display=Display()``,
+    so for them ``execute_graphql`` never raises at all: the decorator reports the failure
+    and hands back nothing. The raising tests above pin a door those two never come through,
+    and the empty-response message is the whole of what they show a playbook author.
+    """
+    display = mocker.MagicMock()
+    processor = _decorated_processor(RuntimeError("Server returned HTTP 502"), display=display)
+
+    with pytest.raises(Exception) as excinfo:
+        processor.fetch_and_process(query=QUERY)
+
+    message = str(excinfo.value)
+    assert "no response" in message.lower()
+    assert "logged above" in message.lower()
+    assert "-vvv" in message
+    # And the reason really is not on the logged line: the catch-all branch keeps it
+    # behind `display.verbose(..., caplevel=2)`, which is why the message says -vvv
+    # rather than telling people to read a reason that was never printed.
+    display.warning.assert_called_once()
+    assert "Server returned HTTP 502" not in display.warning.call_args[0][0]
+    display.verbose.assert_any_call("Full error: Server returned HTTP 502", caplevel=2)
+
+
+def test_display_attached_graphql_error_puts_the_reason_on_screen(mocker):
+    """The one branch where the reason is already visible without ``-vvv``.
+
+    ``GraphQLError`` is handled ahead of the catch-all and logs a second warning carrying
+    the server's own message. The swallowed call still arrives here as an empty response,
+    so the message does not change -- its ``-vvv`` pointer is a floor, not a claim that
+    the reason is missing.
+    """
+    display = mocker.MagicMock()
+    original = GraphQLError(errors=[{"message": "Zone 'bng' does not exist"}])
+    processor = _decorated_processor(original, display=display)
+
+    with pytest.raises(Exception) as excinfo:
+        processor.fetch_and_process(query=QUERY)
+
+    assert "no response" in str(excinfo.value).lower()
+    display.warning.assert_any_call("Reason: Zone 'bng' does not exist")
+
+
+def test_display_attached_unresponsive_server_is_logged_as_an_error(mocker):
+    """The message sends authors looking for a warning *or* an error; this is the error.
+
+    ``_handle_exc`` escalates to ``display.error`` for an unreachable or unresponsive
+    server and never logs a warning for it. Naming only one of the two levels would send
+    half the authors hunting for a line that was never logged, so both halves of that
+    sentence need to stay true.
+    """
+    display = mocker.MagicMock()
+    processor = _decorated_processor(ServerNotResponsiveError(url="https://infrahub.example"), display=display)
+
+    with pytest.raises(Exception) as excinfo:
+        processor.fetch_and_process(query=QUERY)
+
+    assert "no response" in str(excinfo.value).lower()
+    display.error.assert_called_once()
+    display.warning.assert_not_called()
 
 
 def test_typo_free_message(mocker):


### PR DESCRIPTION
# Pull Request

## Related Issue

None — found while diagnosing a lookup failure in a customer playbook, where the reported error
pointed at the query text instead of the server-side cause.

## New Behavior

A failing query names why it failed, in both plugins that run one: `plugins/lookup/lookup.py` and
`plugins/action/query_graphql.py` (line 103 has the same `raise AnsibleError(str(exp)) from exp`
shape, so it gets the same improvement).

Both build the client wrapper with a `Display`, and with a `Display` attached
`handle_infrahub_exceptions` logs the failure and returns `None` rather than raising. So the empty
return — not the raised exception — is the path an author actually travels:

```
Failed to execute the GraphQL query: the call returned no response. A line was logged above -- a
warning, or an error when the server was unreachable or unresponsive -- re-run with -vvv to see the
reason itself.
```

That message no longer blames the query; it names both levels the reason can be logged at, and it
stops short of promising the reason is on screen — outside the `GraphQLError` path the decorator
keeps it behind `display.verbose(..., caplevel=2)`.

The raising branch is a guard, reached only by a caller that builds the wrapper without a `Display`.
It is fixed too. The wrapper boxes SDK errors in a bare `Exception(original)`, so the message used to
report the type as `Exception`; `unwrap_wrapped_error` recovers the original, and `_handle_exc` now
chains with `from exc` so the cause is honest at the source:

```
Failed to execute the GraphQL query: GraphQLError: Cannot query field 'nmae'
```

## Contrast to Current Behavior

`InfrahubQueryProcessor.fetch_and_process` caught bare `Exception` and re-raised a message built
only from the query:

```
Failed to execute the grapqhl query '{'ZoneBNG': {'edges': {'node': {'name': {'value': None}}}}}'
```

Two problems compounded there:

1. **The cause was discarded.** No `from exc`, no exception text. `plugins/lookup/lookup.py` re-raises
   whatever comes out of this method as `AnsibleError(str(exc))`, so that one line is the entirety of
   what an author sees — the HTTP status, the GraphQL error list, or the timeout never reached them.
2. **An empty return was reported as a bad query.** `handle_infrahub_exceptions_decorator` is applied
   to every public `InfrahubclientWrapper` method and, whenever a `Display` is attached (which every
   plugin does), it logs and **returns `None`** rather than raising. So a server-side failure arrives
   here as nothing at all, and the old message sent people to inspect their query text for a problem
   that was never in it. What reached the operator is a single line — `display.warning` for most
   failures, `display.error` for an unreachable or unresponsive server — and that line carries the
   reason itself only on the `GraphQLError` path; the others keep it behind
   `display.verbose(..., caplevel=2)`.

This is precisely the trap already documented in
`dev/knowledge/infrahub-sdk-usage.md` ("The wrapper swallows exceptions whenever a Display is
attached — check for a `None` return instead, and treat it as distinct from an empty list"). The two
paths are now separated, and each says something true.

## Discussion: Benefits and Drawbacks

**Benefit:** the lookup plugin's only error surface becomes diagnosable. Every lookup failure
previously collapsed to one uninformative sentence regardless of cause.

**Backwards-compatible:** yes. Same exception type (`Exception`), same raise points, same happy path.
Only the message text and the chained `__cause__` change. Anything matching on the old message string
would need updating, but that string was a typo'd query dump — not a documented contract.

**Drawback:** none identified. The `try`/`except` is kept rather than removed, so the no-`Display`
callers still work as before.

**Scope note:** `_handle_exc` in `plugins/module_utils/exception.py` gains `from exc` on its re-raise.
That file is on every wrapper method's path, but the change only sets `__cause__` on an exception that
was already being raised — no control flow moves. Reworking the decorator to re-raise SDK types
unchanged would be the larger fix, and is deliberately left to its own PR.

Also corrects the `grapqhl` typo.

## Changes to the Documentation

None needed. `dev/knowledge/infrahub-sdk-usage.md` already prescribes this handling; the code now
follows the guidance that was already written down. No plugin docstrings changed, so
`invoke generate-doc` is a no-op.

## Proposed Release Note Entry

Fixed the `lookup` and `query_graphql` plugins reporting every GraphQL failure as a bad query. A
failed call now reports that no response came back and points at the line logged above and at `-vvv`
for the reason, instead of echoing the query text. Where the call raises rather than returning empty,
the underlying error's type and message are included and chained as the exception's cause.

## Test Plan

New: `tests/unit/plugins/module_utils/test_query_processor_errors.py` — 9 tests, written failing first
and each checked against the code it pins:

- a raised failure keeps `__cause__` and its message/type
- through the real decorator with no `Display`, the message names `GraphQLError` / `RuntimeError`
  rather than the wrapper's `Exception` stand-in
- with a `Display` attached — the path both plugins take — the failure arrives as `None` and produces
  the no-response message
- a `GraphQLError` puts `Reason: ...` on screen; an unresponsive server is logged through
  `display.error` and never as a warning
- an empty return points at the logged line and `-vvv`, without echoing the query back
- the `grapqhl` typo is pinned out
- the happy path returns the response unchanged

```bash
uv run pytest tests/unit -q    # 185 passed
uv run mypy .                  # clean, 32 source files
uv run ruff check . && uv run ruff format --check .
```

`invoke tests-sanity` / `invoke tests-unit` are Docker-based and Docker was unavailable on the
authoring machine, so CI is their first run. Note that `invoke lint` shells out to a bare `ruff` from
`PATH` rather than `uv run ruff`; on a machine with an older `ruff` it rejects the `RUF105` selector
in `pyproject.toml` and never reaches the check. CI runs `uv run ruff check .` and is unaffected.

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `develop` branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `lookup` plugin so a failing GraphQL query names the real cause instead of echoing the query text or the wrapper's generic `Exception`.

- Unwraps the bare `Exception` stand-in the client wrapper boxes SDK errors in, so the message names the real error type like `GraphQLError`, not `Exception`.
- Chains the original exception as `__cause__` at the source in `_handle_exc`, and includes its type and message in the error a playbook author sees.
- Reports an empty return as "no response" and names the line logged above — a warning, or an error when the server was unreachable or unresponsive — pointing at `-vvv` for the reason itself.
- Adds tests pinning the display-attached path, where the decorator swallows failures into a `None` return.
- Fixes the `grapqhl` typo and leaves the happy path unchanged.

<sup>Written for commit c00be0390f9fa8addf8e4a0a88fabf75ff7f6ac2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-ansible/pull/392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


