### PR TITLE
Backport Stable

### DIFF
--- a/docs/docs/readme.mdx
+++ b/docs/docs/readme.mdx
@@ -30,12 +30,12 @@ These are the plugins in the `opsmill.infrahub` collection:
 
 <!-- vale off -->
 
-* [artifact_generate](./references/plugins/artifact_generate_module.mdx) – Trigger artifact regeneration in Infrahub
-* [object_file_fetch](./references/plugins/object_file_fetch_module.mdx) – Fetch file content from a CoreFileObject node in Infrahub
-* [branch](./references/plugins/branch_module.mdx) – Creates, Updates or Deletes a branch in Infrahub
 * [artifact_fetch](./references/plugins/artifact_fetch_module.mdx) – Fetch the content of an artifact from Infrahub
 * [node](./references/plugins/node_module.mdx) – Creates, Updates or Deletes a node in Infrahub
+* [branch](./references/plugins/branch_module.mdx) – Creates, Updates or Deletes a branch in Infrahub
 * [query_graphql](./references/plugins/query_graphql_module.mdx) – Queries and returns elements from Infrahub GraphQL API
+* [object_file_fetch](./references/plugins/object_file_fetch_module.mdx) – Fetch file content from a CoreFileObject node in Infrahub
+* [artifact_generate](./references/plugins/artifact_generate_module.mdx) – Trigger artifact regeneration in Infrahub
 * [schema](./references/plugins/schema_module.mdx) – Load, check, or export schemas in Infrahub
 
 <!-- vale on -->

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ namespace: opsmill
 name: infrahub
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.8.3
+version: 1.9.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub_ansible_modules"
-version = "1.8.3"
+version = "1.9.0"
 description = "Ansible collection to interact with Infrahub's API"
 authors = [{name = "OpsMill", email = "info@opsmill.com"}]
 license = {text = "GPLv3"}

--- a/uv.lock
+++ b/uv.lock
@@ -885,7 +885,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-ansible-modules"
-version = "1.8.3"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Backports version 1.9.0 to the stable branch and reorders the plugin list in the readme alphabetically.

<sup>Written for commit e6f7298bee591e210c8eac7b080fbdd747f2e81e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-ansible/pull/405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

