### PR TITLE
refactor: rename self.client → self.wrapper on processor/module classes

### DIFF
--- a/dev/guides/creating-a-module.md
+++ b/dev/guides/creating-a-module.md
@@ -228,7 +228,7 @@ from ansible_collections.opsmill.infrahub.plugins.module_utils.infrahub_utils im
 class MyModule(InfrahubModule):
     def run(self):
         data = self.data
-        # Implement logic using self.client, self.state, etc.
+        # Implement logic using self.wrapper, self.state, etc.
 
         if self.state == "present":
             self._ensure_object_exists(kind, data)

--- a/dev/knowledge/infrahub-sdk-usage.md
+++ b/dev/knowledge/infrahub-sdk-usage.md
@@ -146,8 +146,8 @@ from ansible_collections.opsmill.infrahub.plugins.module_utils.infrahub_utils im
 class NodeModule(InfrahubModule):
     def run(self):
         kind = self.data.get("kind")
-        schema = self.client.fetch_single_schema(kind=kind, branch=self.branch)
-        self.object = self.client.fetch_single_node(...)
+        schema = self.wrapper.fetch_single_schema(kind=kind, branch=self.branch)
+        self.object = self.wrapper.fetch_single_node(...)
 
         if self.state == "present":
             self._ensure_object_exists(kind, self.data.get("data"))
@@ -158,7 +158,7 @@ class NodeModule(InfrahubModule):
 ### Key Properties and Methods
 
 - `self.module` — the `AnsibleModule` instance
-- `self.client` — `InfrahubclientWrapper` instance (auto-created)
+- `self.wrapper` — `InfrahubclientWrapper` instance (auto-created)
 - `self.state` — `"present"` or `"absent"`
 - `self.data` — module parameters dict
 - `self.branch` — target branch name
@@ -318,17 +318,16 @@ a GraphQL-only count.
 Measured on a ~650-device estate: 50 → 500 cut the request count from 20 to 4 and moved wall-clock the
 wrong way, 7.10s → 7.60s. Fewer, larger pages is not a win here. Concurrency is the lever that helped.
 
-## Naming Trap: `self.client.client`
+## Naming Trap: `self.wrapper.client`
 
 `InfrahubclientWrapper` holds the SDK client as `.client`, and the processors hold the *wrapper* as
-`.client`. So inside `InfrahubNodesProcessor`:
+`.wrapper`. So inside `InfrahubNodesProcessor`:
 
 ```python
-self.client  # the InfrahubclientWrapper
-self.client.client  # the raw InfrahubClientSync
-self.client.client.store  # the SDK's NodeStore
+self.wrapper  # the InfrahubclientWrapper
+self.wrapper.client  # the raw InfrahubClientSync
+self.wrapper.client.store  # the SDK's NodeStore
 ```
 
-`self.client.client` reads like a typo and is not one. A review bot flagged it as such during the
-inventory performance work; applying the suggested "fix" broke three tests. Verify with
-`processor.client.client.store is wrapper.client.store` before changing anything in this area.
+`self.wrapper.client` is two layers deep by design. Verify with
+`processor.wrapper.client.store is wrapper.client.store` before changing anything in this area.

--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -640,7 +640,7 @@ if HAS_INFRAHUBCLIENT:
             client: InfrahubclientWrapper,
             display: Display | None = None,
         ):
-            self.client = client
+            self.wrapper = client
             self.display = display
 
         def _handle_display(
@@ -755,7 +755,7 @@ if HAS_INFRAHUBCLIENT:
             refill: RefillLedger | None = None,
         ) -> list[Any]:
             """Resolve a many-cardinality relationship (RelationshipManagerSync)."""
-            store = self.client.client.store
+            store = self.wrapper.client.store
             peers: list[Any] = []
 
             # Fetch only when the relationship has not been loaded yet. Guarding on
@@ -811,7 +811,7 @@ if HAS_INFRAHUBCLIENT:
                 # a round-trip per host node to learn an id we hold.
                 return node_attr.id
 
-            store = self.client.client.store
+            store = self.wrapper.client.store
             related_node = store.get(key=node_attr.id, raise_when_missing=False)
             if not related_node:
                 node_attr.fetch()
@@ -1030,7 +1030,7 @@ if HAS_INFRAHUBCLIENT:
             # Snapshot rather than read the running total: the counter belongs to the
             # client, which outlives a single call. Reporting the absolute value would
             # attribute an earlier run's requests to this one.
-            requests_before = request_count(self.client)
+            requests_before = request_count(self.wrapper)
 
             fetched = self._fetch_host_nodes(nodes=nodes, prefetch_relationships=prefetch_relationships)
             if not fetched.nodes:
@@ -1047,12 +1047,12 @@ if HAS_INFRAHUBCLIENT:
                 return None
 
             warmer = PeerWarmer(
-                fetch=self.client.fetch_nodes,
-                store=self.client.client.store,
+                fetch=self.wrapper.fetch_nodes,
+                store=self.wrapper.client.store,
                 # One id short of a full page. The SDK's non-parallel pager only stops
                 # once `count - (offset + pagination_size)` goes negative, so a chunk of
                 # exactly `pagination_size` costs a second, empty round-trip.
-                page_size=max(1, self.client.client.pagination_size - 1),
+                page_size=max(1, self.wrapper.client.pagination_size - 1),
                 on_error=lambda kind, exc: self._handle_display(
                     exception=exc,
                     message=f"Failed to fetch peers for kind '{kind}'",
@@ -1172,7 +1172,7 @@ if HAS_INFRAHUBCLIENT:
                 warmer (PeerWarmer | None): carries the per-kind tallies. ``None`` when
                     the query matched no hosts, so nothing was warmed.
             """
-            requests_now = request_count(self.client)
+            requests_now = request_count(self.wrapper)
             unavailable = requests_before is None or requests_now is None
             cost = "unavailable" if unavailable else f"{requests_now - requests_before} request(s)"
             # "node(s)", not "related node(s)": the refill pass shares this warmer, so
@@ -1252,7 +1252,7 @@ if HAS_INFRAHUBCLIENT:
                 # Relying on the decorator alone is not enough: it is attached in
                 # __init__, so any caller that builds the wrapper another way gets the
                 # raw SchemaNotFoundError instead.
-                node_schema = self.client.fetch_single_schema(kind=node_kind, raise_when_missing=False)
+                node_schema = self.wrapper.fetch_single_schema(kind=node_kind, raise_when_missing=False)
                 if node_schema is None:
                     # An unknown kind -- a typo, or a kind that does not exist on this
                     # branch. Skip it the way a failed fetch is skipped: reading
@@ -1283,7 +1283,7 @@ if HAS_INFRAHUBCLIENT:
                     resolvable_attrs=self.get_attributes_for_schema(schema=fetched.schemas[node_kind], exclude=exclude),
                 )
                 try:
-                    nodes_from_kind = self.client.fetch_nodes(
+                    nodes_from_kind = self.wrapper.fetch_nodes(
                         kind=node_kind,
                         include=projection.include,
                         exclude=projection.exclude,
@@ -1528,7 +1528,7 @@ if HAS_INFRAHUBCLIENT:
                     replaces the node in the store rather than mutating the instance in
                     hand, so the second pass has to look it up again.
             """
-            store = self.client.client.store
+            store = self.wrapper.client.store
             resolved: dict[str, Any] = {}
 
             for host_node, attrs, ledger in self._resolution_passes(fetched=fetched, refill=refill):
@@ -1618,7 +1618,7 @@ if HAS_INFRAHUBCLIENT:
             Returns:
                 InfrahubNodeSync: the node created in Infrahub
             """
-            schema = self.client.fetch_single_schema(kind=kind, raise_when_missing=False)
+            schema = self.wrapper.fetch_single_schema(kind=kind, raise_when_missing=False)
             if not schema:
                 raise Exception(f"Non-existing kind '{kind}'")
 
@@ -1644,7 +1644,7 @@ if HAS_INFRAHUBCLIENT:
                 raise Exception(f"Validation failed: {', '.join(validation_errors)}")
 
             try:
-                node = self.client.create_node(kind=kind, data=data)
+                node = self.wrapper.create_node(kind=kind, data=data)
             except Exception as exc:
                 raise Exception(f"Failed to create node with {data} for kind '{kind}' due to {exc}")
 
@@ -1658,7 +1658,7 @@ if HAS_INFRAHUBCLIENT:
                 node (InfrahubNodeSync): the node to save in Infrahub
             """
             try:
-                self.client.save_node(node=node)
+                self.wrapper.save_node(node=node)
             except Exception as exc:
                 raise Exception(f"Failed to save node {node} {exc}")
 
@@ -1672,7 +1672,7 @@ if HAS_INFRAHUBCLIENT:
 
             """
             try:
-                self.client.delete_node(node=node)
+                self.wrapper.delete_node(node=node)
 
             except Exception as exc:
                 self._handle_display(
@@ -1699,7 +1699,9 @@ if HAS_INFRAHUBCLIENT:
                 BranchData | str: Details of the specified branch.
             """
             try:
-                branch_data = self.client.create_branch(name=name, description=description, sync_with_git=sync_with_git)
+                branch_data = self.wrapper.create_branch(
+                    name=name, description=description, sync_with_git=sync_with_git
+                )
             except Exception as exc:
                 raise Exception(f"Failed to create InfrahubBranch with '{name}' due to {exc}")
             if not branch_data:
@@ -1718,7 +1720,7 @@ if HAS_INFRAHUBCLIENT:
                 BranchData  |str: Details of the specified branch.
             """
             try:
-                success = self.client.delete_branch(name=name)
+                success = self.wrapper.delete_branch(name=name)
             except Exception as exc:
                 raise Exception(f"Failed to delete InfrahubBranch with '{name}' due to {exc}")
             if not success:
@@ -1748,7 +1750,7 @@ if HAS_INFRAHUBCLIENT:
                 return None
 
             if isinstance(query, dict):
-                query_str = self.client._render_query(query=query, variables=variables)
+                query_str = self.wrapper._render_query(query=query, variables=variables)
             elif isinstance(query, str):
                 query_str = query
             else:
@@ -1756,7 +1758,7 @@ if HAS_INFRAHUBCLIENT:
 
             results = {}
             try:
-                response = self.client.execute_graphql(query=query_str, variables=variables)
+                response = self.wrapper.execute_graphql(query=query_str, variables=variables)
             except Exception as exc:
                 # Defensive: the client wrapper's exception decorator only re-raises for
                 # a caller that built the wrapper without a Display. Both shipped plugins
@@ -1841,7 +1843,7 @@ if HAS_INFRAHUBCLIENT:
 
             try:
                 if client is None:
-                    self.client = InfrahubclientWrapper(
+                    self.wrapper = InfrahubclientWrapper(
                         api_endpoint=api_endpoint,
                         token=token,
                         branch=branch,
@@ -1849,7 +1851,7 @@ if HAS_INFRAHUBCLIENT:
                         validate_certs=validate_certs,
                     )
                 else:
-                    self.client = client
+                    self.wrapper = client
             except Exception as exc:
                 self._handle_errors(msg=str(exc))
 
@@ -1922,7 +1924,7 @@ if HAS_INFRAHUBCLIENT:
                 BranchData | None: The BranchData or None if not found.
             """
             try:
-                node = self.client.fetch_branch(name=name)
+                node = self.wrapper.fetch_branch(name=name)
             # TODO: Until https://github.com/opsmill/infrahub-sdk-python/issues/269
             except Exception as exc:
                 if exc.__class__ == BranchNotFoundError:
@@ -1956,7 +1958,7 @@ if HAS_INFRAHUBCLIENT:
 
             include = [key for key in data if key not in ("id", "hfid")] or None
             try:
-                node = self.client.fetch_single_node(
+                node = self.wrapper.fetch_single_node(
                     kind=kind, id=node_id, hfid=node_hfid, include=include, raise_when_missing=False
                 )
             except Exception as exc:
@@ -1974,7 +1976,7 @@ if HAS_INFRAHUBCLIENT:
             Returns:
                 tuple(object, diff): tuple of the InfrahubNodeSync created in Infrahub and the Ansible diff.
             """
-            processor = InfrahubNodesProcessor(client=self.client)
+            processor = InfrahubNodesProcessor(client=self.wrapper)
             branch_name = data.get("name")
             branch_description = data.get("description") or ""
             sync_with_git = data.get("sync_with_git")
@@ -1999,7 +2001,7 @@ if HAS_INFRAHUBCLIENT:
                 dict: Ansible diff.
             """
             try:
-                processor = InfrahubNodesProcessor(client=self.client)
+                processor = InfrahubNodesProcessor(client=self.wrapper)
                 processor.delete_branch(name=name)
             except Exception as exc:
                 self._handle_errors(msg=str(exc))
@@ -2018,7 +2020,7 @@ if HAS_INFRAHUBCLIENT:
             Returns:
                 tuple(object, diff): tuple of the InfrahubNodeSync created in Infrahub and the Ansible diff.
             """
-            processor = InfrahubNodesProcessor(client=self.client)
+            processor = InfrahubNodesProcessor(client=self.wrapper)
             try:
                 node = processor.create_node(kind=kind, data=data)
                 if not self.check_mode:
@@ -2053,12 +2055,12 @@ if HAS_INFRAHUBCLIENT:
 
             def get_or_fetch_node(node_id: str) -> InfrahubNodeSync | None:
                 """Get node from store or fetch it (without prefetch to avoid recursion)."""
-                related_node = self.client.client.store.get(key=node_id, raise_when_missing=False)
+                related_node = self.wrapper.client.store.get(key=node_id, raise_when_missing=False)
                 if related_node:
                     return related_node
                 # Node not in store, fetch it directly
                 try:
-                    related_node = self.client.client.get(
+                    related_node = self.wrapper.client.get(
                         kind=rel_schema.peer,
                         id=node_id,
                         populate_store=True,
@@ -2243,7 +2245,7 @@ if HAS_INFRAHUBCLIENT:
             """
             if not self.check_mode:
                 try:
-                    processor = InfrahubNodesProcessor(client=self.client)
+                    processor = InfrahubNodesProcessor(client=self.wrapper)
                     processor.delete_node(self.infrahub_node)
                 except Exception as exc:
                     self._handle_errors(msg=str(exc))

--- a/plugins/module_utils/node.py
+++ b/plugins/module_utils/node.py
@@ -36,7 +36,7 @@ class NodeModule(InfrahubModule):
 
         self.result: dict[str, Any] = {"changed": False}
 
-        schema = self.client.fetch_single_schema(kind=kind, raise_when_missing=False)
+        schema = self.wrapper.fetch_single_schema(kind=kind, raise_when_missing=False)
         if not schema:
             self._handle_errors(msg=f"Non-existing kind '{kind}'")
 
@@ -73,7 +73,7 @@ class NodeModule(InfrahubModule):
 
         # US2: return file content if fetch_file is requested
         if fetch_file and not self.check_mode and self.infrahub_node:
-            file_content = self.client.fetch_file_content(self.infrahub_node)
+            file_content = self.wrapper.fetch_file_content(self.infrahub_node)
             self.result.update(file_content)
 
         serialized_object = None
@@ -82,7 +82,7 @@ class NodeModule(InfrahubModule):
             # After create, raw data lacks server-populated fields (id, file_name,
             # checksum, etc.). Re-fetch to get the complete object.
             if (raw is None or "id" not in raw) and self.infrahub_node.id:
-                self.infrahub_node = self.client.fetch_single_node(
+                self.infrahub_node = self.wrapper.fetch_single_node(
                     kind=kind, id=self.infrahub_node.id, raise_when_missing=False
                 )
             if self.infrahub_node:
@@ -118,7 +118,7 @@ class NodeModule(InfrahubModule):
         if is_file_object and not schema.human_friendly_id and "id" not in data and file_path:
             file_name = Path(file_path).name
             try:
-                return self.client.fetch_single_node(
+                return self.wrapper.fetch_single_node(
                     kind=kind, filters={"file_name__value": file_name}, raise_when_missing=False
                 )
             except Exception as exc:
@@ -167,7 +167,7 @@ class NodeModule(InfrahubModule):
         Returns:
             tuple(InfrahubNodeSync, dict): The created node and the Ansible diff.
         """
-        processor = InfrahubNodesProcessor(client=self.client)
+        processor = InfrahubNodesProcessor(client=self.wrapper)
         try:
             node = processor.create_node(kind=kind, data=data)
             if not self.check_mode:
@@ -190,7 +190,7 @@ class NodeModule(InfrahubModule):
         Returns:
             tuple(InfrahubNodeSync, dict | None): The node and the Ansible diff (None if unchanged).
         """
-        local_checksum = self.client.get_file_object_local_checksum(file_path)
+        local_checksum = self.wrapper.get_file_object_local_checksum(file_path)
         server_checksum = self.infrahub_node.checksum.value
         file_changed = local_checksum != server_checksum
 

--- a/plugins/module_utils/schema.py
+++ b/plugins/module_utils/schema.py
@@ -51,7 +51,7 @@ if HAS_INFRAHUBCLIENT:
 
             try:
                 if client is None:
-                    self.client = InfrahubclientWrapper(
+                    self.wrapper = InfrahubclientWrapper(
                         api_endpoint=api_endpoint,
                         token=token,
                         branch=branch,
@@ -59,7 +59,7 @@ if HAS_INFRAHUBCLIENT:
                         validate_certs=validate_certs,
                     )
                 else:
-                    self.client = client
+                    self.wrapper = client
             except Exception as exc:
                 self.module.fail_json(msg=str(exc), changed=False)
 
@@ -148,7 +148,7 @@ if HAS_INFRAHUBCLIENT:
                 return
 
             try:
-                response = self.client.client.schema.load(
+                response = self.wrapper.client.schema.load(
                     schemas=schemas,
                     branch=branch,
                     wait_until_converged=wait_until_converged,
@@ -179,7 +179,7 @@ if HAS_INFRAHUBCLIENT:
         def _check_for_check_mode(self, schemas: list[dict[str, Any]], branch: str) -> None:
             """Run schema check as a substitute for load in check mode."""
             try:
-                valid, response = self.client.client.schema.check(
+                valid, response = self.wrapper.client.schema.check(
                     schemas=schemas,
                     branch=branch,
                 )
@@ -206,7 +206,7 @@ if HAS_INFRAHUBCLIENT:
             branch = self.module.params.get("branch") or "main"
 
             try:
-                valid, response = self.client.client.schema.check(
+                valid, response = self.wrapper.client.schema.check(
                     schemas=schemas,
                     branch=branch,
                 )
@@ -237,7 +237,7 @@ if HAS_INFRAHUBCLIENT:
                 kwargs["namespaces"] = namespaces
 
             try:
-                exported = self.client.client.schema.export(**kwargs)
+                exported = self.wrapper.client.schema.export(**kwargs)
             except Exception as exc:
                 self.module.fail_json(msg=f"Failed to export schema: {exc}", changed=False)
 

--- a/tests/integration/processor/test_fetch_and_process_integration.py
+++ b/tests/integration/processor/test_fetch_and_process_integration.py
@@ -169,7 +169,7 @@ class TestFetchAndProcessIntegration(TestInfrahubDockerClient):
         original_recorder = client_sync.config.custom_recorder
         client_sync.config.custom_recorder = counter
         processor = processor_for(client_sync)
-        processor.client.request_counter = counter
+        processor.wrapper.request_counter = counter
         processor.display = _CapturingDisplay()
 
         try:

--- a/tests/unit/plugins/module_utils/test_fetch_and_process_resolution.py
+++ b/tests/unit/plugins/module_utils/test_fetch_and_process_resolution.py
@@ -43,7 +43,7 @@ def _make_processor(mocker, nodes_by_kind, attrs=None):
     )
     wrapper.fetch_nodes.side_effect = lambda kind, **kw: list(nodes_by_kind.get(kind, []))
     # Nothing is in the store, so every referenced peer counts as needing a load.
-    # `self.client` IS this wrapper, so the processor's `self.client.client.store`
+    # `self.wrapper` IS this wrapper, so the processor's `self.wrapper.client.store`
     # resolves to `wrapper.client.store` -- the mock stubbed here.
     wrapper.client.store.get.return_value = None
     wrapper.client.pagination_size = 50

--- a/tests/unit/plugins/modules/test_branch.py
+++ b/tests/unit/plugins/modules/test_branch.py
@@ -23,19 +23,19 @@ def _module(mocker, *, state, existing_branch):
     mod.check_mode = False
     mod.state = state
     mod.data = {"name": BRANCH, "description": "d", "sync_with_git": False}
-    mod.client = mocker.Mock()
+    mod.wrapper = mocker.Mock()
     # _get_branch -> client.fetch_branch(name=...)
-    mod.client.fetch_branch.return_value = existing_branch
+    mod.wrapper.fetch_branch.return_value = existing_branch
     return mod
 
 
 def test_create_branch_marks_changed(mocker):
     mod = _module(mocker, state="present", existing_branch=None)
-    mod.client.create_branch.return_value = mocker.Mock()
+    mod.wrapper.create_branch.return_value = mocker.Mock()
 
     mod.run()
 
-    mod.client.create_branch.assert_called_once()
+    mod.wrapper.create_branch.assert_called_once()
     assert mod.result["changed"] is True
     assert "created" in mod.result["msg"]
 
@@ -45,7 +45,7 @@ def test_existing_branch_is_idempotent(mocker):
 
     mod.run()
 
-    mod.client.create_branch.assert_not_called()
+    mod.wrapper.create_branch.assert_not_called()
     assert mod.result["changed"] is False
     assert "already exists" in mod.result["msg"]
 
@@ -55,7 +55,7 @@ def test_delete_existing_branch_marks_changed(mocker):
 
     mod.run()
 
-    mod.client.delete_branch.assert_called_once_with(name=BRANCH)
+    mod.wrapper.delete_branch.assert_called_once_with(name=BRANCH)
     assert mod.result["changed"] is True
     assert "deleted" in mod.result["msg"]
 
@@ -65,6 +65,6 @@ def test_delete_missing_branch_is_idempotent(mocker):
 
     mod.run()
 
-    mod.client.delete_branch.assert_not_called()
+    mod.wrapper.delete_branch.assert_not_called()
     assert mod.result["changed"] is False
     assert "already absent" in mod.result["msg"]

--- a/tests/unit/plugins/modules/test_branch.py
+++ b/tests/unit/plugins/modules/test_branch.py
@@ -24,7 +24,7 @@ def _module(mocker, *, state, existing_branch):
     mod.state = state
     mod.data = {"name": BRANCH, "description": "d", "sync_with_git": False}
     mod.wrapper = mocker.Mock()
-    # _get_branch -> client.fetch_branch(name=...)
+    # _get_branch -> wrapper.fetch_branch(name=...)
     mod.wrapper.fetch_branch.return_value = existing_branch
     return mod
 

--- a/tests/unit/plugins/modules/test_node.py
+++ b/tests/unit/plugins/modules/test_node.py
@@ -26,7 +26,7 @@ def _module(mocker, *, state="present", check_mode=False, infrahub_node=None):
     mod.module.fail_json = mocker.Mock(side_effect=AssertionError("unexpected fail_json"))
     mod.check_mode = check_mode
     mod.state = state
-    mod.client = mocker.Mock()
+    mod.wrapper = mocker.Mock()
     mod.result = {"changed": False}
     mod.infrahub_node = infrahub_node
     return mod
@@ -116,23 +116,23 @@ def _schema(mocker):
 
 def test_create_check_mode_does_not_save(mocker, _schema):
     mod = _module(mocker, check_mode=True)
-    mod.client.fetch_single_schema.return_value = _schema
-    mod.client.create_node.return_value = _node(mocker)
+    mod.wrapper.fetch_single_schema.return_value = _schema
+    mod.wrapper.create_node.return_value = _node(mocker)
 
     mod._create_object(kind=KIND, data={"name": "thing1"})
 
-    mod.client.create_node.assert_called_once()
-    mod.client.save_node.assert_not_called()
+    mod.wrapper.create_node.assert_called_once()
+    mod.wrapper.save_node.assert_not_called()
 
 
 def test_create_persists_when_not_check_mode(mocker, _schema):
     mod = _module(mocker, check_mode=False)
-    mod.client.fetch_single_schema.return_value = _schema
-    mod.client.create_node.return_value = _node(mocker)
+    mod.wrapper.fetch_single_schema.return_value = _schema
+    mod.wrapper.create_node.return_value = _node(mocker)
 
     mod._create_object(kind=KIND, data={"name": "thing1"})
 
-    mod.client.save_node.assert_called_once()
+    mod.wrapper.save_node.assert_called_once()
 
 
 def test_delete_check_mode_does_not_delete(mocker):
@@ -140,7 +140,7 @@ def test_delete_check_mode_does_not_delete(mocker):
 
     mod._delete_object()
 
-    mod.client.delete_node.assert_not_called()
+    mod.wrapper.delete_node.assert_not_called()
 
 
 def test_delete_calls_client_when_not_check_mode(mocker):
@@ -148,4 +148,4 @@ def test_delete_calls_client_when_not_check_mode(mocker):
 
     mod._delete_object()
 
-    mod.client.delete_node.assert_called_once()
+    mod.wrapper.delete_node.assert_called_once()


### PR DESCRIPTION
## Summary

- `InfrahubBaseProcessor` and `InfrahubModule` both stored the SDK wrapper under `self.client`, shadowing the real SDK client accessible as `self.wrapper.client`
- Renamed the attribute to `self.wrapper` across all callsites in `infrahub_utils.py`, `node.py`, and `schema.py`, plus all test fixtures, assertions, and dev docs
- Pure rename — no behaviour change; tests updated as a necessary consequence of the rename

Fixes #379

## Test plan

- [ ] `invoke tests-unit` — all unit tests pass with renamed mock attribute
- [ ] `invoke tests-sanity` — no import or lint regressions
- [ ] `uv run mypy .` — no new type errors
- [ ] `invoke generate-doc` — doc output unchanged