### PR TITLE
refactor: typecheck infrahub_utils.py and run mypy from invoke lint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,8 @@ Full verification before a PR: `invoke format && invoke lint && invoke tests-san
 
 `invoke lint` runs mypy, so it now covers everything CI's `python-lint` job checks. Nothing under `plugins/` is excluded from the typecheck.
 
+One limit to know: `ansible_collections.opsmill.infrahub.*` is not importable outside an installed collection tree, and `ignore_missing_imports` is on, so anything a plugin imports from a sibling `module_utils` resolves to `Any`. Types are checked within a file and against `infrahub-sdk`, but not across the collection's own modules.
+
 `invoke lint` is not purely a check: its first step is `autoflake --in-place --remove-all-unused-imports --remove-unused-variables`, which edits your working tree before ruff ever runs. Expect it to leave modified files behind, and review that diff rather than assuming a linter only reported.
 
 New-module walkthrough: [dev/guides/creating-a-module.md](dev/guides/creating-a-module.md). Test execution detail: [dev/guides/running-tests.md](dev/guides/running-tests.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ This file is the portable router: repo-wide facts every agent needs up front. De
 ## Commands
 
 ```bash
-invoke lint            # autoflake (rewrites files!) + ruff + yamllint + rumdl -- NOT mypy, see below
+invoke lint            # autoflake (rewrites files!) + ruff + mypy + yamllint + rumdl
 invoke format          # Auto-fix (ruff)
 invoke tests-sanity    # Ansible compliance (boilerplate, docs, imports)
 invoke tests-unit      # Unit tests
@@ -43,11 +43,10 @@ All tests run in Docker. Run checks as you go, not just at the end:
 | any plugin file (`plugins/**/*.py`) | `invoke format` → `invoke lint` → `invoke tests-sanity` |
 | module logic or `module_utils` | also `invoke tests-unit` |
 | module docstrings (DOCUMENTATION / EXAMPLES / RETURN) | `invoke generate-doc` |
-| any Python file | also `uv run mypy .` -- `invoke lint` does **not** run it, CI does |
 
-Full verification before a PR: `invoke format && invoke lint && uv run mypy . && invoke tests-sanity && invoke tests-unit && invoke generate-doc`.
+Full verification before a PR: `invoke format && invoke lint && invoke tests-sanity && invoke tests-unit && invoke generate-doc`.
 
-`uv run mypy .` is listed separately because `invoke lint` does not include it while CI's `python-lint` job does — a green `invoke lint` is not a green CI. Note also that mypy currently **excludes** `plugins/module_utils/infrahub_utils.py`, so the collection's largest file is not typechecked at all.
+`invoke lint` runs mypy, so it now covers everything CI's `python-lint` job checks. Nothing under `plugins/` is excluded from the typecheck.
 
 `invoke lint` is not purely a check: its first step is `autoflake --in-place --remove-all-unused-imports --remove-unused-variables`, which edits your working tree before ruff ever runs. Expect it to leave modified files behind, and review that diff rather than assuming a linter only reported.
 

--- a/dev/guidelines/python.md
+++ b/dev/guidelines/python.md
@@ -140,6 +140,13 @@ uv run mypy .
 (`[tool.mypy]` in `pyproject.toml`), so an unannotated helper or a stale `# type: ignore` fails the
 build. Only `tests/` is excluded — every file under `plugins/` is checked.
 
+Cross-module types are not, though. `ansible_collections.opsmill.infrahub.plugins.module_utils.*`
+only resolves inside an installed collection tree, so with `ignore_missing_imports` on, every symbol
+imported that way (`PeerWarmer`, `NodeProjection`, `InfrahubModule` as a base class, …) is `Any` to
+mypy. A subclass in `node.py` is checked against an `Any` base, which is to say barely. Treat a green
+mypy as "this file is internally consistent and uses the SDK correctly", not as
+"the collection typechecks end to end".
+
 Where the SDK's own types defeat the checker — `InfrahubNodeSync.__getattr__` returning a union, the
 `Literal`-keyed `get`/`filters` overloads, the two mutually exclusive `HAS_INFRAHUBCLIENT` blocks —
 suppress at the site with a narrow `# type: ignore[code]` and say why in a comment. Do not widen the

--- a/dev/guidelines/python.md
+++ b/dev/guidelines/python.md
@@ -149,9 +149,9 @@ mypy as "this file is internally consistent and uses the SDK correctly", not as
 
 Where the SDK's own types defeat the checker — `InfrahubNodeSync.__getattr__` returning a union, the
 `Literal`-keyed `get`/`filters` overloads, the two mutually exclusive `HAS_INFRAHUBCLIENT` blocks —
-suppress at the site with a narrow `# type: ignore[code]` and say why in a comment. Do not widen the
-config: `warn_unused_ignores` retires an inline ignore once it stops being needed, and it cannot do
-that for an exclusion.
+suppress at the site with a narrow `# type: ignore[code]`. Do not widen the config:
+`warn_unused_ignores` retires an inline ignore once it stops being needed, and it cannot do that for
+an exclusion. The error code carries the reason — do not add a comment restating it.
 
 ## Dependencies
 

--- a/dev/guidelines/python.md
+++ b/dev/guidelines/python.md
@@ -130,20 +130,21 @@ Use modern type hints (`str | None` not `Optional[str]`). The `from __future__ i
 
 ### mypy
 
-CI runs `uv run mypy .` as part of the `python-lint` job. **`invoke lint` does not**, so a clean
-`invoke lint` can still fail CI — run mypy explicitly before opening a PR:
+`invoke lint` runs mypy, and so does CI's `python-lint` job. To run it on its own:
 
 ```bash
 uv run mypy .
 ```
 
-Two things to know about the current configuration (`[tool.mypy]` in `pyproject.toml`):
+`warn_return_any`, `disallow_untyped_defs`, and `warn_unused_ignores` are all on
+(`[tool.mypy]` in `pyproject.toml`), so an unannotated helper or a stale `# type: ignore` fails the
+build. Only `tests/` is excluded — every file under `plugins/` is checked.
 
-- `warn_return_any`, `disallow_untyped_defs`, and `warn_unused_ignores` are all on, so an unannotated
-  helper or a stale `# type: ignore` fails the build.
-- `plugins/module_utils/infrahub_utils.py` is **excluded**. That is the largest file in the collection,
-  so a change confined to it gets no type checking whatsoever. Do not read "mypy passed" as "this file
-  is checked".
+Where the SDK's own types defeat the checker — `InfrahubNodeSync.__getattr__` returning a union, the
+`Literal`-keyed `get`/`filters` overloads, the two mutually exclusive `HAS_INFRAHUBCLIENT` blocks —
+suppress at the site with a narrow `# type: ignore[code]` and say why in a comment. Do not widen the
+config: `warn_unused_ignores` retires an inline ignore once it stops being needed, and it cannot do
+that for an exclusion.
 
 ## Dependencies
 

--- a/dev/guidelines/testing.md
+++ b/dev/guidelines/testing.md
@@ -215,7 +215,7 @@ Tests run on every PR to `develop`:
 1. **Linter job** — Ruff check + format, **mypy**, yamllint, rumdl, Vale
 2. **Ansible linter and tests job** — ansible-lint, sanity tests, unit tests
 
-`invoke lint` covers ruff, yamllint, and rumdl — but **not mypy**. Run `uv run mypy .` separately, or
-the first sign of a type error will be a red CI job.
+`invoke lint` covers ruff, mypy, yamllint, and rumdl, so it matches what the linter job checks
+(bar Vale).
 
 The CI workflow is in `.github/workflows/trigger-pr-develop.yml`.

--- a/dev/guides/running-tests.md
+++ b/dev/guides/running-tests.md
@@ -171,10 +171,10 @@ git worktree add ../infrahub-baseline develop
 ## Linting (Not Tests, But Related)
 
 ```bash
-# Run all linters (ruff check + ruff format + yamllint + rumdl) -- does NOT run mypy
+# Run all linters (ruff check + ruff format + mypy + yamllint + rumdl)
 invoke lint
 
-# Type checking is a separate command, and CI runs it
+# Type checking on its own
 uv run mypy .
 
 # Auto-fix formatting

--- a/dev/guides/running-tests.md
+++ b/dev/guides/running-tests.md
@@ -171,7 +171,7 @@ git worktree add ../infrahub-baseline develop
 ## Linting (Not Tests, But Related)
 
 ```bash
-# Run all linters (ruff check + ruff format + mypy + yamllint + rumdl)
+# Run all lint steps (autoflake rewrites Python files + ruff check + ruff format + mypy + yamllint + rumdl)
 invoke lint
 
 # Type checking on its own

--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
     from ansible.module_utils.basic import AnsibleModule, Display
     from infrahub_sdk.branch import BranchData
+    from infrahub_sdk.schema import MainSchemaTypesAPI
 
 try:
     from infrahub_sdk import Config, InfrahubClientSync
@@ -32,7 +33,6 @@ try:
         RelationshipManagerSync,
     )
     from infrahub_sdk.schema import (
-        MainSchemaTypesAPI,
         RelationshipCardinality,
         RelationshipKind,
     )
@@ -1386,6 +1386,9 @@ if HAS_INFRAHUBCLIENT:
             # No schema fetch for the peer kinds: `resolve_node_mapping` reads a node's
             # own `_schema`, never the `schemas` mapping it is handed, so loading them
             # here would be a round-trip nothing reads back.
+            # `PeerWarmer` comes in through an `ansible_collections.*` path mypy cannot resolve,
+            # so `warm` reads as returning `Any` even though it is annotated `-> int`. The cast is
+            # only here to satisfy `warn_return_any`; it goes away once that import resolves.
             return cast("int", warmer.warm(referenced))
 
         @staticmethod

--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -769,6 +769,9 @@ if HAS_INFRAHUBCLIENT:
                 return [peer.id for peer in node_attr.peers if peer.id]
 
             for peer in node_attr.peers:
+                # `peer.id` is `str | None` on the SDK side. Guarding it here would change what
+                # this loop does with an id-less peer, so the existing behaviour stands: the store
+                # rejects None just as loudly as mypy does.
                 related_node: Any = store.get(key=peer.id, raise_when_missing=False)  # type: ignore[arg-type]
                 if not related_node:
                     peer.fetch()
@@ -1531,6 +1534,8 @@ if HAS_INFRAHUBCLIENT:
             resolved: dict[str, Any] = {}
 
             for host_node, attrs, ledger in self._resolution_passes(fetched=fetched, refill=refill):
+                # As above: `host_node.id` is optional to the store's signature, and narrowing it
+                # here would add a branch that does not exist today.
                 node = (
                     (store.get(key=host_node.id, raise_when_missing=False) or host_node)  # type: ignore[arg-type]
                     if refreshed
@@ -1818,7 +1823,7 @@ if HAS_INFRAHUBCLIENT:
 
         """
 
-        # Both are set by the subclasses (NodeModule, BranchModule) before any method
+        # All three are set by the subclasses (NodeModule, BranchModule) before any method
         # declared here runs, so they are declared -- not assigned -- at class level.
         result: dict[str, Any]
         infrahub_node: InfrahubNodeSync | None

--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -192,9 +192,6 @@ if HAS_INFRAHUBCLIENT:
                 filters=filters,
                 branch=branch,
             )
-            # `InfrahubNodeSync.__getattr__` is typed `Attribute | RelationshipManagerSync |
-            # RelatedNodeSync`, so mypy cannot tell that an attribute we name explicitly is
-            # always the `Attribute` arm. Same reason for every other `union-attr` ignore below.
             resp = self.client._get(url=f"{self.client.address}/api/storage/object/{node.storage_id.value}")  # type: ignore[union-attr]
             if node.content_type.value == "application/json":  # type: ignore[union-attr]
                 result["json"] = resp.json()
@@ -769,9 +766,6 @@ if HAS_INFRAHUBCLIENT:
                 return [peer.id for peer in node_attr.peers if peer.id]
 
             for peer in node_attr.peers:
-                # `peer.id` is `str | None` on the SDK side. Guarding it here would change what
-                # this loop does with an id-less peer, so the existing behaviour stands: the store
-                # rejects None just as loudly as mypy does.
                 related_node: Any = store.get(key=peer.id, raise_when_missing=False)  # type: ignore[arg-type]
                 if not related_node:
                     peer.fetch()
@@ -1389,9 +1383,6 @@ if HAS_INFRAHUBCLIENT:
             # No schema fetch for the peer kinds: `resolve_node_mapping` reads a node's
             # own `_schema`, never the `schemas` mapping it is handed, so loading them
             # here would be a round-trip nothing reads back.
-            # `PeerWarmer` comes in through an `ansible_collections.*` path mypy cannot resolve,
-            # so `warm` reads as returning `Any` even though it is annotated `-> int`. The cast is
-            # only here to satisfy `warn_return_any`; it goes away once that import resolves.
             return cast("int", warmer.warm(referenced))
 
         @staticmethod
@@ -1534,8 +1525,6 @@ if HAS_INFRAHUBCLIENT:
             resolved: dict[str, Any] = {}
 
             for host_node, attrs, ledger in self._resolution_passes(fetched=fetched, refill=refill):
-                # As above: `host_node.id` is optional to the store's signature, and narrowing it
-                # here would add a branch that does not exist today.
                 node = (
                     (store.get(key=host_node.id, raise_when_missing=False) or host_node)  # type: ignore[arg-type]
                     if refreshed
@@ -1823,9 +1812,6 @@ if HAS_INFRAHUBCLIENT:
 
         """
 
-        # Set by the subclasses before any method declared here runs, so they are declared --
-        # not assigned -- at class level. Both subclasses set `result`; `infrahub_node` is
-        # NodeModule's and `branch` is BranchModule's.
         result: dict[str, Any]
         infrahub_node: InfrahubNodeSync | None
         branch: BranchData | str | None
@@ -1984,9 +1970,6 @@ if HAS_INFRAHUBCLIENT:
                 tuple(object, diff): tuple of the branch created in Infrahub and the Ansible diff.
             """
             processor = InfrahubNodesProcessor(client=self.client)
-            # `data` is the untyped Ansible parameter dict, so `.get` gives back `Any | None`.
-            # Annotating the locals as `Any` keeps that -- rather than claiming a narrower type
-            # the parameter dict does not guarantee.
             branch_name: Any = data.get("name")
             branch_description = data.get("description") or ""
             sync_with_git: Any = data.get("sync_with_git")
@@ -2056,7 +2039,6 @@ if HAS_INFRAHUBCLIENT:
             if rel_value is None:
                 return None
 
-            # Only called from `_update_object`, which has already established the node exists.
             node = cast("InfrahubNodeSync", self.infrahub_node)
 
             rel_schema = next(
@@ -2171,9 +2153,6 @@ if HAS_INFRAHUBCLIENT:
             Returns:
                 tuple(object, diff): tuple of the InfrahubNodeSync created in Infrahub and the Ansible diff.
             """
-            # Reached only from `_ensure_object_exists` (and `NodeModule._update_object_with_file`,
-            # which it calls), both of which branch on `self.infrahub_node` being set first.
-            # The alias is the same object -- it just carries the non-optional type.
             node = cast("InfrahubNodeSync", self.infrahub_node)
 
             # Capture the "before" state by serializing the original node's data
@@ -2264,8 +2243,6 @@ if HAS_INFRAHUBCLIENT:
             if not self.check_mode:
                 try:
                     processor = InfrahubNodesProcessor(client=self.client)
-                    # Reached only from `_ensure_object_absent`, which branches on
-                    # `self.infrahub_node` being set before calling in here.
                     processor.delete_node(cast("InfrahubNodeSync", self.infrahub_node))
                 except Exception as exc:
                     self._handle_errors(msg=str(exc))

--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -8,7 +8,7 @@ import traceback
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from ansible.module_utils.basic import env_fallback
 from ansible_collections.opsmill.infrahub.plugins.module_utils.exception import handle_infrahub_exceptions_decorator
@@ -17,7 +17,7 @@ from ansible_collections.opsmill.infrahub.plugins.module_utils.peers import Peer
 from ansible_collections.opsmill.infrahub.plugins.module_utils.projection import NodeProjection
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterator, MutableMapping
 
     from ansible.module_utils.basic import AnsibleModule, Display
     from infrahub_sdk.branch import BranchData
@@ -32,9 +32,7 @@ try:
         RelationshipManagerSync,
     )
     from infrahub_sdk.schema import (
-        GenericSchemaAPI,
-        NodeSchemaAPI,
-        ProfileSchemaAPI,
+        MainSchemaTypesAPI,
         RelationshipCardinality,
         RelationshipKind,
     )
@@ -119,8 +117,8 @@ if HAS_INFRAHUBCLIENT:
             api_endpoint: str,
             token: str,
             branch: str | None = None,
-            timeout: int | None = 10,
-            validate_certs: bool | None = True,
+            timeout: int = 10,
+            validate_certs: bool = True,
             display: Display | None = None,
         ):
             """
@@ -185,7 +183,7 @@ if HAS_INFRAHUBCLIENT:
             Returns:
                 dict: Artifact Content
             """
-            result = {
+            result: dict[str, Any] = {
                 "json": None,
                 "text": None,
             }
@@ -194,8 +192,11 @@ if HAS_INFRAHUBCLIENT:
                 filters=filters,
                 branch=branch,
             )
-            resp = self.client._get(url=f"{self.client.address}/api/storage/object/{node.storage_id.value}")
-            if node.content_type.value == "application/json":
+            # `InfrahubNodeSync.__getattr__` is typed `Attribute | RelationshipManagerSync |
+            # RelatedNodeSync`, so mypy cannot tell that an attribute we name explicitly is
+            # always the `Attribute` arm. Same reason for every other `union-attr` ignore below.
+            resp = self.client._get(url=f"{self.client.address}/api/storage/object/{node.storage_id.value}")  # type: ignore[union-attr]
+            if node.content_type.value == "application/json":  # type: ignore[union-attr]
                 result["json"] = resp.json()
             else:
                 result["text"] = resp.text
@@ -232,7 +233,7 @@ if HAS_INFRAHUBCLIENT:
             }
 
             # Step 1: Fetch the artifact node for the target_id
-            lookup_filters = filters.copy()
+            lookup_filters: dict[str, Any] = filters.copy()
             lookup_filters["object__ids"] = [target_id]
             node = self.fetch_single_node(
                 kind="CoreArtifact",
@@ -246,8 +247,8 @@ if HAS_INFRAHUBCLIENT:
                 return result
 
             result["artifact_id"] = node.id
-            result["artifact_name"] = node.name.value
-            result["definition_id"] = node.definition.id
+            result["artifact_name"] = node.name.value  # type: ignore[union-attr]
+            result["definition_id"] = node.definition.id  # type: ignore[union-attr]
 
             # Step 2: Trigger regeneration using the artifact ID
             url = f"{self.client.address}/api/artifact/generate/{result['definition_id']}?branch={branch}"
@@ -291,12 +292,12 @@ if HAS_INFRAHUBCLIENT:
                 order=order,
             )
             for node in nodes:
-                resp = self.client._get(url=f"{self.client.address}/api/storage/object/{node.storage_id.value}")
+                resp = self.client._get(url=f"{self.client.address}/api/storage/object/{node.storage_id.value}")  # type: ignore[union-attr]
                 result: dict[str, Any] = {
                     "json": None,
                     "text": None,
                 }
-                if node.content_type.value == "application/json":
+                if node.content_type.value == "application/json":  # type: ignore[union-attr]
                     result["json"] = resp.json()
                 else:
                     result["text"] = resp.text
@@ -313,8 +314,8 @@ if HAS_INFRAHUBCLIENT:
             exclude: list[str] | None = None,
             filters: dict[str, str] | None = None,
             branch: str | None = None,
-            prefetch_relationships: bool | None = True,
-            raise_when_missing: bool | None = False,
+            prefetch_relationships: bool = True,
+            raise_when_missing: bool = False,
         ) -> InfrahubNodeSync:
             """
             Retrieve a single node of a given kind based on filters
@@ -336,8 +337,9 @@ if HAS_INFRAHUBCLIENT:
             if not filters and not hfid and not id:
                 raise Exception("At least one filter must be provided.")
 
+            node: InfrahubNodeSync
             if filters:
-                node = self.client.get(
+                node = self.client.get(  # type: ignore[call-overload,misc]
                     kind=kind,
                     id=id,
                     hfid=hfid,
@@ -370,7 +372,7 @@ if HAS_INFRAHUBCLIENT:
             exclude: list[str] | None = None,
             filters: dict[str, str] | None = None,
             branch: str | None = None,
-            prefetch_relationships: bool | None = True,
+            prefetch_relationships: bool = True,
             order: Order | None = None,
             parallel: bool = True,
         ) -> list[InfrahubNodeSync]:
@@ -405,7 +407,7 @@ if HAS_INFRAHUBCLIENT:
                     order=order,
                 )
             else:
-                nodes = self.client.filters(
+                nodes = self.client.filters(  # type: ignore[call-overload]
                     kind=kind,
                     include=include,
                     populate_store=True,
@@ -423,8 +425,8 @@ if HAS_INFRAHUBCLIENT:
             self,
             kind: str,
             branch: str | None = None,
-            raise_when_missing: bool | None = True,
-        ) -> NodeSchemaAPI | GenericSchemaAPI | ProfileSchemaAPI:
+            raise_when_missing: bool = True,
+        ) -> MainSchemaTypesAPI | None:
             """
             Retrieves schema attributes for the given kind.
 
@@ -434,7 +436,8 @@ if HAS_INFRAHUBCLIENT:
                 raise_when_missing (bool, optional): Whether to raise an exception if the schema is not found. Defaults to True.
 
             Returns:
-                NodeSchemaAPI | GenericSchemaAPI | ProfileSchemaAPI: The schema attributes for the given kind.
+                MainSchemaTypesAPI | None: The schema attributes, or None when the kind is unknown
+                    and raise_when_missing is False.
             """
             if raise_when_missing:
                 return self.client.schema.get(kind=kind, branch=branch)
@@ -443,9 +446,7 @@ if HAS_INFRAHUBCLIENT:
             except SchemaNotFoundError:
                 return None
 
-        def fetch_schemas(
-            self, branch: str | None = None
-        ) -> dict[str, NodeSchemaAPI | GenericSchemaAPI | ProfileSchemaAPI] | None:
+        def fetch_schemas(self, branch: str | None = None) -> MutableMapping[str, MainSchemaTypesAPI] | None:
             """
             Retrieves schema attributes for the given kind.
 
@@ -453,7 +454,7 @@ if HAS_INFRAHUBCLIENT:
                 branch (str, optional): Name of the branch to query from. Defaults to default_branch.
 
             Returns:
-                dict[str, NodeSchemaAPI | GenericSchemaAPI | ProfileSchemaAPI]:: A dict of node kind, Schema.
+                MutableMapping[str, MainSchemaTypesAPI]: A mapping of node kind, Schema.
             """
             branch = branch or self.client.config.default_branch
             return self.client.schema.all(branch=branch)
@@ -531,9 +532,7 @@ if HAS_INFRAHUBCLIENT:
             """
             return self.client.create(kind=kind, data=data, branch=branch, kwargs=kwargs)
 
-        def create_branch(
-            self, name: str, description: str | None = "", sync_with_git: bool = False
-        ) -> BranchData | str:
+        def create_branch(self, name: str, description: str = "", sync_with_git: bool = False) -> BranchData | str:
             """
             Create a new InfrahubBranch with provided attributes
 
@@ -598,8 +597,8 @@ if HAS_INFRAHUBCLIENT:
             Returns:
                 dict: {"binary": base64_str, "text": str_or_None}
             """
-            content: bytes = node.download_file()
-            is_text = node.file_type.value in TEXT_MIME_TYPES
+            content = cast("bytes", node.download_file())
+            is_text = node.file_type.value in TEXT_MIME_TYPES  # type: ignore[union-attr]
             return {
                 "binary": base64.b64encode(content).decode("ascii"),
                 "text": content.decode("utf-8", errors="replace") if is_text else None,
@@ -631,7 +630,7 @@ if HAS_INFRAHUBCLIENT:
                 branch=branch,
                 raise_when_missing=True,
             )
-            content: bytes = node.download_file()
+            content = cast("bytes", node.download_file())
             return node, content
 
     class InfrahubBaseProcessor:
@@ -743,7 +742,7 @@ if HAS_INFRAHUBCLIENT:
 
             if "node" not in refetch_cache:
                 refetch_cache["node"] = node._client.get(id=node.id, kind=node._schema.kind)
-            tmp_attr = getattr(refetch_cache["node"], root_attr, None)
+            tmp_attr: Any = getattr(refetch_cache["node"], root_attr, None)
             return str(tmp_attr.value) if tmp_attr.value else tmp_attr.value
 
         def _resolve_many_relationship(
@@ -771,7 +770,7 @@ if HAS_INFRAHUBCLIENT:
                 return [peer.id for peer in node_attr.peers if peer.id]
 
             for peer in node_attr.peers:
-                related_node = store.get(key=peer.id, raise_when_missing=False)
+                related_node: Any = store.get(key=peer.id, raise_when_missing=False)  # type: ignore[arg-type]
                 if not related_node:
                     peer.fetch()
                     related_node = peer.peer
@@ -969,14 +968,12 @@ if HAS_INFRAHUBCLIENT:
 
     class InfrahubNodesProcessor(InfrahubBaseProcessor):
         @staticmethod
-        def get_attributes_for_schema(
-            schema: NodeSchemaAPI | GenericSchemaAPI | ProfileSchemaAPI, exclude: list[str] | None = None
-        ) -> list[str] | None:
+        def get_attributes_for_schema(schema: MainSchemaTypesAPI, exclude: list[str] | None = None) -> list[str] | None:
             """
             Build the attributes for the given kind.
 
             Parameters:
-                schema (NodeSchemaAPI | GenericSchemaAPI | ProfileSchemaAPI): The schema from which attributes/relationship are used
+                schema (MainSchemaTypesAPI): The schema from which attributes/relationship are used
                 exclude list[str] | None: list of attributes/relationship to ignore
 
             Returns:
@@ -997,10 +994,10 @@ if HAS_INFRAHUBCLIENT:
                 rel_schema = schema.get_relationship_or_none(name=rel_name)
                 if not rel_schema:
                     continue
-                if (
-                    rel_schema.cardinality == RelationshipCardinality.MANY  # type: ignore[union-attr]
-                    and rel_schema.kind not in [RelationshipKind.ATTRIBUTE, RelationshipKind.PARENT]  # type: ignore[union-attr]
-                ):
+                if rel_schema.cardinality == RelationshipCardinality.MANY and rel_schema.kind not in [
+                    RelationshipKind.ATTRIBUTE,
+                    RelationshipKind.PARENT,
+                ]:
                     continue
                 if rel_schema and rel_schema.cardinality in (RelationshipCardinality.ONE, RelationshipCardinality.MANY):
                     attributes_by_kind.append(rel_name)
@@ -1009,7 +1006,7 @@ if HAS_INFRAHUBCLIENT:
         def fetch_and_process(
             self,
             nodes: dict[str, Any],
-            prefetch_relationships: bool | None = True,
+            prefetch_relationships: bool = True,
             include_id: bool = True,
         ) -> dict[str, Any] | None:
             """
@@ -1233,7 +1230,7 @@ if HAS_INFRAHUBCLIENT:
                 return []
             return ["Inventory fetch cost, by kind:", *lines]
 
-        def _fetch_host_nodes(self, nodes: dict[str, Any], prefetch_relationships: bool | None) -> HostFetch:
+        def _fetch_host_nodes(self, nodes: dict[str, Any], prefetch_relationships: bool) -> HostFetch:
             """Fetch every requested kind, narrowed to what the user actually asked for.
 
             Parameters:
@@ -1390,7 +1387,7 @@ if HAS_INFRAHUBCLIENT:
             # No schema fetch for the peer kinds: `resolve_node_mapping` reads a node's
             # own `_schema`, never the `schemas` mapping it is handed, so loading them
             # here would be a round-trip nothing reads back.
-            return warmer.warm(referenced)
+            return cast("int", warmer.warm(referenced))
 
         @staticmethod
         def _resolution_passes(
@@ -1532,7 +1529,11 @@ if HAS_INFRAHUBCLIENT:
             resolved: dict[str, Any] = {}
 
             for host_node, attrs, ledger in self._resolution_passes(fetched=fetched, refill=refill):
-                node = (store.get(key=host_node.id, raise_when_missing=False) or host_node) if refreshed else host_node
+                node = (
+                    (store.get(key=host_node.id, raise_when_missing=False) or host_node)  # type: ignore[arg-type]
+                    if refreshed
+                    else host_node
+                )
                 result = self.resolve_node_mapping(
                     node=node,
                     attrs=attrs,
@@ -1623,7 +1624,7 @@ if HAS_INFRAHUBCLIENT:
                 raise Exception(f"Non-existing kind '{kind}'")
 
             # TODO: Should be replace after https://github.com/opsmill/infrahub-sdk-python/issues/268
-            validation_errors = []
+            validation_errors: list[str] = []
             validation_errors.extend(
                 f"Required attribute '{attr.name}' missing for '{kind}"
                 for attr in schema.attributes
@@ -1666,7 +1667,7 @@ if HAS_INFRAHUBCLIENT:
             if not node.id:
                 raise Exception(f"Failed to save node {node}")
 
-        def delete_node(self, node: InfrahubNodeSync) -> bool:
+        def delete_node(self, node: InfrahubNodeSync) -> InfrahubNodeSync:
             """
             Delete a node from Infrahub
 
@@ -1684,9 +1685,7 @@ if HAS_INFRAHUBCLIENT:
 
             return node
 
-        def create_branch(
-            self, name: str, description: str | None = "", sync_with_git: bool = False
-        ) -> BranchData | str:
+        def create_branch(self, name: str, description: str = "", sync_with_git: bool = False) -> BranchData | str:
             """
             Create an InfrahubBranch
 
@@ -1817,6 +1816,12 @@ if HAS_INFRAHUBCLIENT:
 
         """
 
+        # Both are set by the subclasses (NodeModule, BranchModule) before any method
+        # declared here runs, so they are declared -- not assigned -- at class level.
+        result: dict[str, Any]
+        infrahub_node: InfrahubNodeSync | None
+        branch: BranchData | str | None
+
         def __init__(self, module: AnsibleModule, client: InfrahubclientWrapper | None = None) -> None:
             self.module = module
             self.state = self.module.params["state"]
@@ -1856,7 +1861,7 @@ if HAS_INFRAHUBCLIENT:
             # TODO: cleanup and normalized data ?
             self.data = module.params
 
-        def _handle_errors(self, msg: Any):
+        def _handle_errors(self, msg: Any) -> None:
             """
             Returns message and changed = False
 
@@ -1879,9 +1884,7 @@ if HAS_INFRAHUBCLIENT:
             return {"before": before, "after": after}
 
         # TODO: Should be replace after https://github.com/opsmill/infrahub-sdk-python/issues/267
-        def rebuild_hfid_from_data(
-            self, schema: NodeSchemaAPI | GenericSchemaAPI | ProfileSchemaAPI, data: dict
-        ) -> list[str] | None:
+        def rebuild_hfid_from_data(self, schema: MainSchemaTypesAPI, data: dict) -> list[str] | None:
             """
             Rebuild the HFID filters from the provided data based on a schema human_friendly_id.
 
@@ -1898,7 +1901,7 @@ if HAS_INFRAHUBCLIENT:
             """
             hfid_values = []
             # Iterate over each composite key defined in the schema.
-            for composite in schema.human_friendly_id:
+            for composite in schema.human_friendly_id:  # type: ignore[union-attr]
                 # Split the composite key into individual field names.
                 element = composite.split("__")[0]
                 value = data.get(element)
@@ -1933,9 +1936,7 @@ if HAS_INFRAHUBCLIENT:
                 )
             return node
 
-        def _get_object(
-            self, schema: NodeSchemaAPI | GenericSchemaAPI | ProfileSchemaAPI, kind: str, data: dict
-        ) -> InfrahubNodeSync | None:
+        def _get_object(self, schema: MainSchemaTypesAPI, kind: str, data: dict) -> InfrahubNodeSync | None:
             """
             Build filters based on the data, and retrieve a single object with these filters
 
@@ -1964,7 +1965,7 @@ if HAS_INFRAHUBCLIENT:
 
             return node
 
-        def _create_branch(self, data: dict) -> tuple[InfrahubNodeSync, dict]:
+        def _create_branch(self, data: dict) -> tuple[BranchData | str, dict]:
             """
             Create an InfrahubBranch after validating required fields.
 
@@ -1972,12 +1973,15 @@ if HAS_INFRAHUBCLIENT:
                 data (dict): The data for this object
 
             Returns:
-                tuple(object, diff): tuple of the InfrahubNodeSync created in Infrahub and the Ansible diff.
+                tuple(object, diff): tuple of the branch created in Infrahub and the Ansible diff.
             """
             processor = InfrahubNodesProcessor(client=self.client)
-            branch_name = data.get("name")
+            # `data` is the untyped Ansible parameter dict, so `.get` gives back `Any | None`.
+            # Annotating the locals as `Any` keeps that -- rather than claiming a narrower type
+            # the parameter dict does not guarantee.
+            branch_name: Any = data.get("name")
             branch_description = data.get("description") or ""
-            sync_with_git = data.get("sync_with_git")
+            sync_with_git: Any = data.get("sync_with_git")
             try:
                 branch = processor.create_branch(
                     name=branch_name, description=branch_description, sync_with_git=sync_with_git
@@ -2044,8 +2048,11 @@ if HAS_INFRAHUBCLIENT:
             if rel_value is None:
                 return None
 
+            # Only called from `_update_object`, which has already established the node exists.
+            node = cast("InfrahubNodeSync", self.infrahub_node)
+
             rel_schema = next(
-                (rel for rel in self.infrahub_node._schema.relationships if rel.name == rel_name),
+                (rel for rel in node._schema.relationships if rel.name == rel_name),
                 None,
             )
             if not rel_schema:
@@ -2146,7 +2153,7 @@ if HAS_INFRAHUBCLIENT:
 
             return rel_value
 
-        def _update_object(self, data: dict) -> tuple[InfrahubNodeSync, dict]:
+        def _update_object(self, data: dict) -> tuple[InfrahubNodeSync, dict | None]:
             """
             Update an Infrahub Object.
 
@@ -2156,15 +2163,20 @@ if HAS_INFRAHUBCLIENT:
             Returns:
                 tuple(object, diff): tuple of the InfrahubNodeSync created in Infrahub and the Ansible diff.
             """
+            # Reached only from `_ensure_object_exists` (and `NodeModule._update_object_with_file`,
+            # which it calls), both of which branch on `self.infrahub_node` being set first.
+            # The alias is the same object -- it just carries the non-optional type.
+            node = cast("InfrahubNodeSync", self.infrahub_node)
+
             # Capture the "before" state by serializing the original node's data
             # We avoid using deepcopy on the node because InfrahubNodeSync contains
             # a reference to InfrahubClientSync which has an SSLContext that cannot be pickled
-            serialized_before = deepcopy(self.infrahub_node._generate_input_data().get("data", {}).get("data", {}))
+            serialized_before = deepcopy(node._generate_input_data().get("data", {}).get("data", {}))
 
             # Normalize relationship UUIDs to HFIDs in the "before" state
             # This ensures consistent comparison when user provides HFID but stored data has UUID
             for key in list(serialized_before.keys()):
-                if key in self.infrahub_node._schema.relationship_names:
+                if key in node._schema.relationship_names:
                     serialized_before[key] = self._normalize_rel_id_to_hfid(key, serialized_before.get(key))
                     # Also normalize the format (e.g., {"hfid": ["single"]} -> {"id": "single"})
                     serialized_before[key] = self._normalize_rel_format(serialized_before[key])
@@ -2172,36 +2184,36 @@ if HAS_INFRAHUBCLIENT:
             # TODO: SDK should provide a way to do that
             # https://github.com/opsmill/infrahub-sdk-python/issues/272
             for attr_name in data:
-                if attr_name in self.infrahub_node._schema.attribute_names:
+                if attr_name in node._schema.attribute_names:
                     attr_value = data.get(attr_name)
                     # Unwrap {"value": ...} dicts from Ansible data format —
                     # setattr on SDK node attributes expects the raw value.
                     if isinstance(attr_value, dict) and "value" in attr_value:
                         attr_value = attr_value["value"]
                     setattr(
-                        self.infrahub_node,
+                        node,
                         attr_name,
                         attr_value,
                     )
-                elif attr_name in self.infrahub_node._schema.relationship_names:
-                    rel_schema = next(rel for rel in self.infrahub_node._schema.relationships if rel.name == attr_name)
+                elif attr_name in node._schema.relationship_names:
+                    rel_schema = next(rel for rel in node._schema.relationships if rel.name == attr_name)
                     rel_data = data.get(attr_name)
                     if rel_schema.cardinality == RelationshipCardinality.ONE:
-                        setattr(self.infrahub_node, f"_{attr_name}", None)
+                        setattr(node, f"_{attr_name}", None)
                         setattr(
-                            self.infrahub_node,
+                            node,
                             attr_name,
                             rel_data,
                         )
                     elif rel_schema.cardinality == RelationshipCardinality.MANY:
                         setattr(
-                            self.infrahub_node,
+                            node,
                             attr_name,
                             RelationshipManagerSync(
                                 name=attr_name,
-                                client=self.infrahub_node._client,
-                                node=self.infrahub_node,
-                                branch=self.infrahub_node._branch,
+                                client=node._client,
+                                node=node,
+                                branch=node._branch,
                                 schema=rel_schema,
                                 data=rel_data,
                             ),
@@ -2209,16 +2221,16 @@ if HAS_INFRAHUBCLIENT:
 
             # TODO: SDK should provide a way to do that too ...
             # https://github.com/opsmill/infrahub-sdk-python/issues/271
-            serialized_after = self.infrahub_node._generate_input_data().get("data", {}).get("data", {})
+            serialized_after = node._generate_input_data().get("data", {}).get("data", {})
 
             # Normalize relationship formats in the "after" state to match "before" canonical format
             # This handles cases where _generate_input_data() produces {"hfid": ["single"]} but we normalized to {"id": "single"}
             for key in list(serialized_after.keys()):
-                if key in self.infrahub_node._schema.relationship_names:
+                if key in node._schema.relationship_names:
                     serialized_after[key] = self._normalize_rel_format(serialized_after.get(key))
 
             if dict_hash(serialized_before) == dict_hash(serialized_after):
-                return self.infrahub_node, None
+                return node, None
 
             data_before, data_after = {}, {}
             for key in data:
@@ -2229,10 +2241,10 @@ if HAS_INFRAHUBCLIENT:
                     data_after[key] = key_after
 
             if not self.check_mode:
-                self.infrahub_node.update()
+                node.update()
 
             diff = self._build_diff(before=data_before, after=data_after)
-            return self.infrahub_node, diff
+            return node, diff
 
         def _delete_object(self) -> dict:
             """
@@ -2244,7 +2256,9 @@ if HAS_INFRAHUBCLIENT:
             if not self.check_mode:
                 try:
                     processor = InfrahubNodesProcessor(client=self.client)
-                    processor.delete_node(self.infrahub_node)
+                    # Reached only from `_ensure_object_absent`, which branches on
+                    # `self.infrahub_node` being set before calling in here.
+                    processor.delete_node(cast("InfrahubNodeSync", self.infrahub_node))
                 except Exception as exc:
                     self._handle_errors(msg=str(exc))
 
@@ -2281,7 +2295,7 @@ if HAS_INFRAHUBCLIENT:
             if not self.branch:
                 self.result["msg"] = f"InfrahubBranch {data.get('name')} already absent"
             else:
-                branch_name = data.get("name")
+                branch_name: Any = data.get("name")
                 diff = self._delete_branch(name=branch_name)
                 self.result["msg"] = f"InfrahubBranch {branch_name} deleted"
                 self.result["changed"] = True
@@ -2298,6 +2312,7 @@ if HAS_INFRAHUBCLIENT:
                 data (dict):  User defined data passed into the module
             """
             object_data = data.get("data") or {}
+            diff: dict | None
             if not self.infrahub_node:
                 self.result["msg"] = data
                 self.infrahub_node, diff = self._create_object(kind=kind, data=object_data)
@@ -2334,7 +2349,7 @@ if HAS_INFRAHUBCLIENT:
                 self.result["changed"] = True
                 self.result["diff"] = diff
 
-        def run(self):
+        def run(self) -> None:
             """
             Must be implemented in subclasses
             """
@@ -2343,17 +2358,17 @@ if HAS_INFRAHUBCLIENT:
 
 if not HAS_INFRAHUBCLIENT:
 
-    def get_node_identifier(_node) -> str:  # type: ignore[misc]
+    def get_node_identifier(_node: Any) -> str:  # type: ignore[misc]
         return "unknown"
 
-    class InfrahubclientWrapper:
+    class InfrahubclientWrapper:  # type: ignore[no-redef]
         pass
 
-    class InfrahubNodesProcessor:
+    class InfrahubNodesProcessor:  # type: ignore[no-redef]
         pass
 
-    class InfrahubQueryProcessor:
+    class InfrahubQueryProcessor:  # type: ignore[no-redef]
         pass
 
-    class InfrahubModule:
+    class InfrahubModule:  # type: ignore[no-redef]
         pass

--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -712,8 +712,7 @@ if HAS_INFRAHUBCLIENT:
 
             The return type is deliberately wide: a populated value is stringified, but a
             falsy-but-present one (``False``, ``0``, ``""``) is handed back as it came, so
-            this is not ``str | None``. mypy does not currently check this file, so the
-            annotation is the only thing saying so.
+            this is not ``str | None``.
 
             An attribute can come back empty for two different reasons: the server
             answered null, or nobody asked for it. The second happens whenever the

--- a/plugins/module_utils/infrahub_utils.py
+++ b/plugins/module_utils/infrahub_utils.py
@@ -1823,8 +1823,9 @@ if HAS_INFRAHUBCLIENT:
 
         """
 
-        # All three are set by the subclasses (NodeModule, BranchModule) before any method
-        # declared here runs, so they are declared -- not assigned -- at class level.
+        # Set by the subclasses before any method declared here runs, so they are declared --
+        # not assigned -- at class level. Both subclasses set `result`; `infrahub_node` is
+        # NodeModule's and `branch` is BranchModule's.
         result: dict[str, Any]
         infrahub_node: InfrahubNodeSync | None
         branch: BranchData | str | None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,9 +75,7 @@ ignore_missing_imports = true
 disallow_untyped_defs = true
 warn_return_any = true
 warn_unused_ignores = true
-# Exclude problematic module that has complex try/except patterns
 exclude = [
-    "plugins/module_utils/infrahub_utils\\.py$",
     "tests/",
 ]
 

--- a/specs/001-inventory-fetch-performance/quickstart.md
+++ b/specs/001-inventory-fetch-performance/quickstart.md
@@ -5,14 +5,13 @@ How to reproduce the claims in the spec, and what to run before touching this co
 ## Verify correctness
 
 ```bash
-invoke format && invoke lint          # autoflake + ruff (check + format) + yamllint + rumdl
-uv run mypy .                         # NOT part of `invoke lint` -- run it explicitly
+invoke format && invoke lint          # autoflake + ruff (check + format) + mypy + yamllint + rumdl
 invoke tests-sanity                   # ansible-test sanity, Docker
 invoke tests-unit                     # 106 unit tests
 ```
 
-`invoke lint` does not run mypy, and a failing `ruff check` masks the steps after it. Both have bitten
-this feature; run mypy separately.
+`invoke lint` runs mypy as of #378; it used to not, and running it separately was a step this feature
+needed. A failing `ruff check` still masks the steps after it, so read the whole output.
 
 ## Verify the round-trip budgets
 

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -11,6 +11,7 @@ def lint_all(context: Context) -> None:
     """This will run all linter."""
     lint_autoflake(context)
     lint_ruff(context)
+    lint_mypy(context)
     lint_yaml(context)
     lint_markdown(context)
 
@@ -52,6 +53,15 @@ def lint_ruff(context: Context) -> None:
     print(f" - [{NAMESPACE}] Check code with ruff")
     exec_cmd = f"ruff format --check --diff {MAIN_DIRECTORY} &&"
     exec_cmd += f"ruff check --diff {MAIN_DIRECTORY}"
+    with context.cd(ESCAPED_REPO_PATH):
+        context.run(exec_cmd)
+
+
+@task
+def lint_mypy(context: Context) -> None:
+    """This will run mypy, the same check as CI's python-lint job."""
+    print(f" - [{NAMESPACE}] Check types with mypy")
+    exec_cmd = f"mypy {MAIN_DIRECTORY}"
     with context.cd(ESCAPED_REPO_PATH):
         context.run(exec_cmd)
 


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #378

## New Behavior

`plugins/module_utils/infrahub_utils.py` is type checked. `[tool.mypy] exclude` now lists only `tests/`, so every file under `plugins/` is covered, and `invoke lint` runs mypy as one of its steps.

## Contrast to Current Behavior

The collection's largest file — 2359 lines holding `InfrahubclientWrapper`, `InfrahubModule`, the processor classes and `INFRAHUB_ARG_SPEC` — was excluded from mypy, so a change confined to it got no type checking while `uv run mypy .` still reported success. `invoke lint` did not run mypy at all, while CI's `python-lint` job did, so a green local lint was not a green CI. The two gaps compounded: the file where most changes land was unchecked, and the command that would have said so was not part of the local run.

Lifting the exclusion surfaced 100 errors. All are fixed. No runtime behaviour changes — the diff is annotations, `cast`s, narrow `# type: ignore[code]`s, and one local alias. Unit and sanity suites are unchanged.

## Discussion: Benefits and Drawbacks

**Benefits.** Several annotations had drifted from the code and are now correct:

- `InfrahubModule` read `self.result`, `self.infrahub_node` and `self.branch` while only its subclasses assigned them — now declared on the base class.
- The hand-written `NodeSchemaAPI | GenericSchemaAPI | ProfileSchemaAPI` union was missing `TemplateSchemaAPI`, which `schema.get`/`schema.all` can return. Replaced by the SDK's own `MainSchemaTypesAPI`.
- `fetch_single_schema` returns `None` when `raise_when_missing=False`; `_update_object` returns `None` for the diff when nothing changed; `delete_node` returns the node, not a `bool`; `_create_branch` returns branch data, not a node. All four said otherwise.
- Two `# type: ignore` comments were unnecessary — the case that motivated the issue.

**Drawbacks and limits.** Everything mypy genuinely cannot see through is suppressed inline at the site with its reason, never by widening the config: the SDK's union-typed `__getattr__`, its `Literal`-keyed `get`/`filters` overloads, the mutually exclusive `HAS_INFRAHUBCLIENT` blocks. `warn_unused_ignores` retires an inline ignore when it stops being needed; it cannot do that for an exclusion.

Coverage is narrower than "no exclusions" suggests, and the docs now say so: `ansible_collections.opsmill.infrahub.*` only resolves inside an installed collection tree, so with `ignore_missing_imports` on, every symbol imported from a sibling `module_utils` is `Any`. `node.py` is checked against an `Any` base class. Making that import resolve is worth its own issue.

The `MainSchemaTypesAPI` move to `TYPE_CHECKING` also takes three `*SchemaAPI` names out of the runtime import probe. `infrahub_sdk.schema` is still imported there for other names, so a missing or broken SDK still flips `HAS_INFRAHUBCLIENT`; only a build missing precisely those three names would now go undetected. Inert above the declared `infrahub-sdk>=1.19.0` floor.

Backwards-compatible: no public interface, argument spec, or module return value changes.

## Changes to the Documentation

- `AGENTS.md` — command list and pre-PR verification now include mypy via `invoke lint`; added the cross-module coverage limit.
- `dev/guidelines/python.md` — rewrote the `### mypy` section: what is checked, what is not, and the rule to suppress inline rather than widen the config.
- `dev/guidelines/testing.md`, `dev/guides/running-tests.md` — both said `invoke lint` does not run mypy.
- `specs/001-inventory-fetch-performance/quickstart.md` — same correction.

## Proposed Release Note Entry

`plugins/module_utils/infrahub_utils.py` is now type checked; mypy no longer excludes it, and `invoke lint` runs mypy.

## Test Plan

```bash
uv run mypy .          # clean, 33 source files (32 before -- infrahub_utils.py is the new one)
invoke lint            # now includes mypy; autoflake rewrites files, review that diff
invoke tests-sanity
invoke tests-unit
```

`invoke tests-integration` was not run — it needs a live Infrahub.

Note: 7 unit tests fail under some `pytest-randomly` orderings and pass in isolation. Identical on `develop`, so not from this branch, but CI may surface it.

## Double Check

* [x] I have explained my PR according to the information in the comments or in a linked issue.
* [x] My PR targets the `develop` branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`plugins/module_utils/infrahub_utils.py` is now type-checked, and `invoke lint` runs mypy alongside the other linters. Previously, the file was excluded and local lint skipped mypy; this closes both gaps without changing runtime behavior or public interfaces. Closes #378.

- Corrects stale return types, SDK schema unions, and subclass-managed attributes.
- Keeps SDK-related suppressions narrow and at the error sites; the error code carries the reason, so no comments restate it.
- Runs mypy through `uv run` so `invoke lint` matches CI's environment; a bare mypy sees a different env, cannot import the SDK, and flags the suppressions as unused.
- Types `_handle_errors` as `NoReturn` since it always raises via `fail_json`; the previous `-> None` hid unbound names at its call sites.
- Updates contributor and testing documentation with the new commands and cross-module coverage limits, and adds a changelog fragment.
- Validates with `uv run mypy .`, `invoke lint`, `invoke tests-sanity`, and `invoke tests-unit`; integration tests still require a live Infrahub.

<sup>Written for commit 2c6e009290a7485dc51422decf56c0b2d8e6a975. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-ansible/pull/410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

