### PR TITLE
docs(specs): specify collapsing develop into a single stable branch

### DIFF
--- a/specs/003-collapse-develop-branch/spec.md
+++ b/specs/003-collapse-develop-branch/spec.md
@@ -46,8 +46,8 @@ Dependabot, the upstream-tracking workflows and CI triggers all operate against 
 
 **Acceptance Scenarios**:
 
-1. **Given** dependabot PRs opened against `develop` before the change, **When** the collapse is complete, **Then** every one of them is closed — their branch names embed the target (`dependabot/pip/develop/...`), so none can be retargeted by rename — and none is left pointing at a deleted branch.
-2. **Given** those PRs are closed, **When** dependabot next runs, **Then** it recreates the still-relevant updates as new PRs on `dependabot/pip/stable/...` branches.
+1. **Given** dependabot PRs opened against `develop` before the change, **When** the collapse is complete, **Then** every one of them is closed — their branch names embed the pinned target (`dependabot/pip/develop/...`), so none can be retargeted by rename — and none is left pointing at a deleted branch.
+2. **Given** those PRs are closed, **When** dependabot next runs, **Then** it recreates the still-relevant updates as new PRs based on `stable`. The head-branch names follow from how FR-008 is satisfied: removing the `target-branch` pin yields `dependabot/pip/all-...` with no branch segment, whereas repinning it to `stable` would yield `dependabot/pip/stable/...`.
 3. **Given** dependabot runs, **When** it opens a dependency PR, **Then** the PR targets `stable`.
 4. **Given** the upstream-tracking workflows run, **When** they select a target branch, **Then** `develop` is not offered.
 5. **Given** a PR is opened against `stable`, **When** CI runs, **Then** the full check set runs — linter, sanity, unit tests, plus documentation checks.
@@ -73,7 +73,7 @@ The constitution, the guidelines and guides under `dev/`, the two READMEs, AGENT
 
 - **PR #405 "Backport Stable"** (`stable` → `develop`) becomes meaningless and must be closed rather than merged.
 - **PR #229** has been open a long time; it may conflict badly when rebased onto `stable` and may be better closed than retargeted. Decide per-PR rather than bulk-retargeting.
-- **Dependabot branch names embed the target** (`dependabot/pip/develop/...`); existing ones are abandoned and recreated rather than renamed.
+- **Dependabot branch names embed `develop` because `.github/dependabot.yml` pins `target-branch: develop`** — the segment comes from that pin, not from whether `develop` is the default branch. Live evidence: `develop` *is* the default branch today, and the open dependabot PR #394 still sits on `dependabot/pip/develop/all-3c79134f2c`; the `github-actions` entry, pinned the same way, produces `dependabot/github_actions/develop/all-...`. Ecosystems the config does not pin carry no branch segment at all (`dependabot/uv/uv-...`). Existing pinned branches are therefore abandoned and recreated, not renamed.
 - **Branch protection currently protects `develop`** — its rules must be transferred to `stable`, not simply deleted, or the repo is briefly unprotected.
 - **`develop` is deleted while a contributor has it checked out locally** — they need `git remote prune` guidance; local copies are otherwise harmless.
 - **A release is in flight during the collapse** — the change must not run concurrently with a release attempt.
@@ -90,7 +90,7 @@ The constitution, the guidelines and guides under `dev/`, the two READMEs, AGENT
 - **FR-005**: `develop` MUST be deleted only after FR-001 through FR-004 are complete and after confirming it holds no commits absent from `stable`.
 - **FR-006**: CI MUST run the full check set — linter, sanity, unit tests, and documentation checks — on every pull request to `stable`.
 - **FR-007**: The `develop`-specific PR trigger workflow MUST be removed and its checks preserved on the `stable` path. `trigger-pr-develop.yml` also carries a `push` trigger on `renovate/**` branches that `trigger-pr-stable.yml` does not; that trigger MUST be rehomed rather than lost with the file.
-- **FR-008**: Dependabot MUST target `stable`. Its existing `develop`-targeted PRs cannot be retargeted in place — the branch name embeds the target (`dependabot/pip/develop/...`) — so they MUST be closed under FR-002 and left for dependabot to recreate against `stable`.
+- **FR-008**: Dependabot MUST target `stable`. `.github/dependabot.yml` pins `target-branch: develop` on both the `github-actions` and the `pip` entry; that pin MUST be removed rather than repointed, so dependabot follows the default branch and no second place has to be kept in sync. Its existing PRs cannot be retargeted in place — the pin puts the target into the head-branch name (`dependabot/pip/develop/...`) — so they MUST be closed under FR-002 and left for dependabot to recreate. Because an unpinned dependabot follows the *default* branch, the pin MUST NOT be removed before FR-001 has made `stable` the default, or the next cycle raises PRs against `develop` again.
 - **FR-009**: The upstream-tracking workflows MUST NOT offer `develop` as a target branch.
 - **FR-010**: The constitution MUST be amended to describe a single-branch model, with a version bump and sync-impact record per its own governance rule. Redefining the branch model is a breaking change to a documented workflow rule, so the bump is MAJOR.
 - **FR-011**: Every repository file that describes the branch model, or instructs a contributor or agent where to branch from or what to target, MUST describe the single-branch model. Enumerated from the tree at specification time:
@@ -112,7 +112,8 @@ The constitution, the guidelines and guides under `dev/`, the two READMEs, AGENT
 - **`develop`**: removed. Currently the default branch, strictly behind `stable`.
 - **Branch protection ruleset**: currently applied to `develop`; transferred to `stable`.
 - **Constitution**: binding governance document encoding the branch model in four places; requires a versioned amendment.
-- **Open pull requests**: six against `develop`, each retargeted or closed by explicit decision.
+- **Open pull requests**: six against `develop` at specification time, each retargeted or closed by explicit decision.
+- **`.github/dependabot.yml`**: pins `target-branch: develop`; the pin is removed so dependabot follows the default branch.
 
 ## Success Criteria *(mandatory)*
 

--- a/specs/003-collapse-develop-branch/spec.md
+++ b/specs/003-collapse-develop-branch/spec.md
@@ -42,23 +42,25 @@ Dependabot, the upstream-tracking workflows and CI triggers all operate against 
 
 **Why this priority**: Without it, automation keeps recreating branches and PRs against a branch that no longer exists. Necessary for the change to stick, but User Story 1 already delivers the contributor-facing value.
 
-**Independent Test**: Let dependabot run a cycle and confirm its PRs target `stable`; trigger the SDK-tracking workflow and confirm it offers only `stable`.
+**Independent Test**: Confirm no open dependabot PR still targets `develop`; let dependabot run a cycle and confirm the PRs it raises target `stable`; trigger the SDK-tracking workflow and confirm it offers only `stable`.
 
 **Acceptance Scenarios**:
 
-1. **Given** dependabot runs, **When** it opens a dependency PR, **Then** the PR targets `stable`.
-2. **Given** the upstream-tracking workflows run, **When** they select a target branch, **Then** `develop` is not offered.
-3. **Given** a PR is opened against `stable`, **When** CI runs, **Then** the full check set runs — linter, sanity, unit tests, plus documentation checks.
+1. **Given** dependabot PRs opened against `develop` before the change, **When** the collapse is complete, **Then** every one of them is closed — their branch names embed the target (`dependabot/pip/develop/...`), so none can be retargeted by rename — and none is left pointing at a deleted branch.
+2. **Given** those PRs are closed, **When** dependabot next runs, **Then** it recreates the still-relevant updates as new PRs on `dependabot/pip/stable/...` branches.
+3. **Given** dependabot runs, **When** it opens a dependency PR, **Then** the PR targets `stable`.
+4. **Given** the upstream-tracking workflows run, **When** they select a target branch, **Then** `develop` is not offered.
+5. **Given** a PR is opened against `stable`, **When** CI runs, **Then** the full check set runs — linter, sanity, unit tests, plus documentation checks.
 
 ---
 
 ### User Story 3 - Documentation describes the branch model that exists (Priority: P3)
 
-The constitution, git-workflow guideline, release guide and AGENTS.md describe a single-branch model, so contributors and coding agents are not instructed to target a branch that is gone.
+The constitution, the guidelines and guides under `dev/`, the two READMEs, AGENTS.md and the pull request template must describe a single-branch model, so that contributors and coding agents are not instructed to target a branch that is gone. Today every one of them still carries the two-branch model — the constitution and the PR template mandate it outright.
 
 **Why this priority**: Stale governance docs are actively misleading — the constitution is binding and currently mandates PRs target `develop`. Lower priority only because the mechanical change works without it; it must not be skipped.
 
-**Independent Test**: Grep the repository for `develop` and confirm every remaining hit is unrelated to the branch model.
+**Independent Test**: Grep the repository for `develop` and confirm every remaining hit is either unrelated to the branch model or one of the two classes FR-012 puts out of scope.
 
 **Acceptance Scenarios**:
 
@@ -87,7 +89,7 @@ The constitution, git-workflow guideline, release guide and AGENTS.md describe a
 - **FR-004**: Branch protection rules on `develop` MUST be transferred to `stable` before `develop` is deleted, leaving no window in which the surviving branch is unprotected.
 - **FR-005**: `develop` MUST be deleted only after FR-001 through FR-004 are complete and after confirming it holds no commits absent from `stable`.
 - **FR-006**: CI MUST run the full check set — linter, sanity, unit tests, and documentation checks — on every pull request to `stable`.
-- **FR-007**: The `develop`-specific PR trigger workflow MUST be removed and its checks preserved on the `stable` path.
+- **FR-007**: The `develop`-specific PR trigger workflow MUST be removed and its checks preserved on the `stable` path. `trigger-pr-develop.yml` also carries a `push` trigger on `renovate/**` branches that `trigger-pr-stable.yml` does not; that trigger MUST be rehomed rather than lost with the file.
 - **FR-008**: Dependabot MUST target `stable`. Its existing `develop`-targeted PRs cannot be retargeted in place — the branch name embeds the target (`dependabot/pip/develop/...`) — so they MUST be closed under FR-002 and left for dependabot to recreate against `stable`.
 - **FR-009**: The upstream-tracking workflows MUST NOT offer `develop` as a target branch.
 - **FR-010**: The constitution MUST be amended to describe a single-branch model, with a version bump and sync-impact record per its own governance rule. Redefining the branch model is a breaking change to a documented workflow rule, so the bump is MAJOR.
@@ -142,7 +144,7 @@ Beyond that list, the implementation **amends the constitution**, whose Governan
 - No release is in flight while the collapse runs.
 - `develop` holds no unique commits — verified as `3 0` against `stable` at specification time, and to be re-verified immediately before deletion.
 - Contributors can be notified to prune local tracking branches; no automated cleanup of clones is attempted.
-- The checks currently running on PRs to `stable` are a superset of those on PRs to `develop`, so consolidating onto `stable` loses no coverage.
+- The checks currently running on PRs to `stable` equal those on PRs to `develop` — `trigger-pr-stable.yml` and `trigger-pr-develop.yml` each call the same two reusable workflows, `workflow-linter.yml` and `workflow-ansible-linter-and-tests.yml`. Neither path runs the documentation and changelog checks: `workflow-changelog-and-docs.yml` is invoked only from `trigger-push-stable.yml`, after a merge. Consolidating onto `stable` therefore loses no coverage, and FR-006 is what adds the full check set to the stable pull-request path.
 - Single-branch delivery is the OpsMill default; the sibling repos already run this way, so this removes a divergence rather than inventing a model.
 
 ## Out of Scope

--- a/specs/003-collapse-develop-branch/spec.md
+++ b/specs/003-collapse-develop-branch/spec.md
@@ -88,11 +88,21 @@ The constitution, git-workflow guideline, release guide and AGENTS.md describe a
 - **FR-005**: `develop` MUST be deleted only after FR-001 through FR-004 are complete and after confirming it holds no commits absent from `stable`.
 - **FR-006**: CI MUST run the full check set — linter, sanity, unit tests, and documentation checks — on every pull request to `stable`.
 - **FR-007**: The `develop`-specific PR trigger workflow MUST be removed and its checks preserved on the `stable` path.
-- **FR-008**: Dependabot MUST target `stable`.
+- **FR-008**: Dependabot MUST target `stable`. Its existing `develop`-targeted PRs cannot be retargeted in place — the branch name embeds the target (`dependabot/pip/develop/...`) — so they MUST be closed under FR-002 and left for dependabot to recreate against `stable`.
 - **FR-009**: The upstream-tracking workflows MUST NOT offer `develop` as a target branch.
 - **FR-010**: The constitution MUST be amended to describe a single-branch model, with a version bump and sync-impact record per its own governance rule. Redefining the branch model is a breaking change to a documented workflow rule, so the bump is MAJOR.
-- **FR-011**: `dev/guidelines/git-workflow.md`, `dev/guides/releasing-the-collection.md`, `dev/README.md` and `AGENTS.md` MUST describe the single-branch model.
-- **FR-012**: No repository file may instruct a contributor or agent to branch from, or target, `develop`.
+- **FR-011**: Every repository file that describes the branch model, or instructs a contributor or agent where to branch from or what to target, MUST describe the single-branch model. Enumerated from the tree at specification time:
+  - `dev/guidelines/git-workflow.md` — the branch table, "PRs target `develop`", the CI-trigger table
+  - `dev/guidelines/testing.md` — "Tests run on every PR to `develop`" and the `trigger-pr-develop.yml` pointer
+  - `dev/guides/releasing-the-collection.md` — the `develop` → `stable` merge presented as the release trigger
+  - `dev/guides/running-tests.md` — the `git worktree add ../infrahub-baseline develop` branch-comparison recipe
+  - `dev/README.md` — the summaries of the git-workflow guideline and the release guide
+  - `AGENTS.md` — the git-workflow pointer, labelled "Branch model (develop/stable)"
+  - `README.md` — "Releasing the current major version happens from the `develop` branch"
+  - `.github/pull_request_template.md` — the "point your PR to the `develop` branch" banner and the "My PR targets the `develop` branch" checklist item
+- **FR-012**: Once FR-007 through FR-011 are complete, no repository file may instruct a contributor or agent to branch from, or target, `develop`. Two classes of remaining `develop` hit are out of scope and MUST NOT be read as violations:
+  - `.github/file-filters.yml` — a comment recounting a past incident ("a ruff bump landed on develop"). It records history and instructs nobody; it may be reworded for accuracy but needs no retargeting.
+  - `.agents/skills/**` — vendored skill copies that list `develop` among generic long-lived branch names (`main`, `master`, `develop`, `stable`) in branch-discipline guards. They describe no branch model of this repository and are corrected upstream in the skills monorepo, if at all.
 
 ### Key Entities
 
@@ -110,20 +120,22 @@ The constitution, git-workflow guideline, release guide and AGENTS.md describe a
 - **SC-002**: 100% of open pull requests are resolved — retargeted to `stable` or closed with a reason — with none left pointing at a deleted branch.
 - **SC-003**: The surviving branch is protected at every point during the change; there is no interval with zero protected long-lived branches.
 - **SC-004**: Zero commits are lost — every commit reachable from `develop` before the change remains reachable from `stable` after it.
-- **SC-005**: A repository-wide search for `develop` returns no hit that refers to the branch model.
+- **SC-005**: A repository-wide search for `develop` returns no hit that refers to this repository's branch model, excluding the two classes FR-012 places out of scope.
 - **SC-006**: The first dependency PR raised after the change targets `stable` without manual intervention.
 
 ## Governance Gates Crossed
 
+This specification changes no workflow, branch, pull request or repository setting — it only proposes the collapse. Everything below is the gate the **implementation** will cross and must have approved before that work lands. Nothing here is done yet.
+
 Per this repository's `AGENTS.md` **Ask First** list:
 
-- [x] **Modifying CI workflows in `.github/workflows/`** — the develop PR trigger is removed and target-branch lists change.
-- [ ] Adding new dependencies — none.
-- [ ] Changing ruff configuration — not touched.
-- [ ] Modifying `plugins/module_utils/infrahub_utils.py` — not touched.
-- [ ] Changing `INFRAHUB_ARG_SPEC` — not touched.
+- **Will cross — Modifying CI workflows in `.github/workflows/`**: the implementation removes `trigger-pr-develop.yml`, adds the documentation and changelog checks to the `stable` PR path, and drops `develop` from the target-branch choices in `update-infrahub.yml` and `update-infrahub-sdk.yml`. As of this specification none of that has happened — `trigger-pr-develop.yml` still triggers on pull requests to `develop`.
+- **Not crossed — Adding new dependencies**: none.
+- **Not crossed — Changing ruff configuration**: not touched.
+- **Not crossed — Modifying `plugins/module_utils/infrahub_utils.py`**: not touched.
+- **Not crossed — Changing `INFRAHUB_ARG_SPEC`**: not touched.
 
-Beyond that list, this feature **amends the constitution**, whose Governance section requires that amendments update the document and the corresponding `dev/knowledge/` and `dev/guidelines/` files in sync. That synchronisation is FR-010 and FR-011, and it is the highest-order gate here — higher than the CI change, because the constitution is binding on every future PR.
+Beyond that list, the implementation **amends the constitution**, whose Governance section requires that amendments update the document and the corresponding `dev/knowledge/` and `dev/guidelines/` files in sync. That synchronisation is FR-010 and FR-011, and it is the highest-order gate here — higher than the CI change, because the constitution is binding on every future PR.
 
 ## Assumptions
 

--- a/specs/003-collapse-develop-branch/spec.md
+++ b/specs/003-collapse-develop-branch/spec.md
@@ -1,0 +1,141 @@
+# Feature Specification: Collapse develop into a single stable branch
+
+**Feature Branch**: `003-collapse-develop-branch`
+
+**Created**: 2026-09-10
+
+**Status**: Draft
+
+**Input**: User description: "Remove the develop branch and run a single long-lived stable branch, retargeting open PRs, workflows, dependabot, docs and the constitution."
+
+## Context
+
+This collection runs `develop` (active development) and `stable` (releases), with releases cut by merging `develop` into `stable`. The two-branch model costs a permanent reconciliation tax and buys nothing here — the sibling repositories (infrahub-mcp on `stable`, infrahub-skills on `main`) each run one long-lived branch.
+
+The model is already inverted in practice. `origin/stable...origin/develop` is **3 ahead, 0 behind**: `develop` contains nothing `stable` lacks, while `stable` carries three commits `develop` does not. Reconciliation runs *backwards* through a standing "Backport Stable" PR (#405). A branch that only ever receives backports is not an integration branch.
+
+Because nothing unique lives on `develop`, the collapse loses no work — there is no merge to perform, only references to repoint.
+
+**Relationship to spec 002**: `002-towncrier-release-process` replaces the release trigger. Today a release *is* the `develop` → `stable` merge; under 002 it becomes a reviewable release PR merged into the single branch. This spec removes the branch; 002 supplies the release mechanism that replaces what the branch was doing. 002 depends on this landing first.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A contributor targets one obvious branch (Priority: P1)
+
+A contributor opens a pull request and there is exactly one branch to target. No decision about `develop` versus a `stable` hotfix, and no possibility of landing work on a branch that is not the one being released.
+
+**Why this priority**: This is the point of the change, and it is the slice that delivers value on its own — even before any workflow or doc cleanup, retargeting PRs and flipping the default branch stops new work landing in the wrong place.
+
+**Independent Test**: Open a new PR with no explicit base and confirm it targets `stable`; confirm CI runs the full check set on it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a contributor pushes a branch and opens a PR without specifying a base, **When** the PR is created, **Then** its base is `stable`.
+2. **Given** an open PR that previously targeted `develop`, **When** the collapse is complete, **Then** it targets `stable` and its CI has re-run green against that base.
+3. **Given** the collapse is complete, **When** anyone attempts to push or open a PR against `develop`, **Then** the branch does not exist.
+
+---
+
+### User Story 2 - Automation points at one branch (Priority: P2)
+
+Dependabot, the upstream-tracking workflows and CI triggers all operate against `stable`, with no `develop`-specific paths left behind.
+
+**Why this priority**: Without it, automation keeps recreating branches and PRs against a branch that no longer exists. Necessary for the change to stick, but User Story 1 already delivers the contributor-facing value.
+
+**Independent Test**: Let dependabot run a cycle and confirm its PRs target `stable`; trigger the SDK-tracking workflow and confirm it offers only `stable`.
+
+**Acceptance Scenarios**:
+
+1. **Given** dependabot runs, **When** it opens a dependency PR, **Then** the PR targets `stable`.
+2. **Given** the upstream-tracking workflows run, **When** they select a target branch, **Then** `develop` is not offered.
+3. **Given** a PR is opened against `stable`, **When** CI runs, **Then** the full check set runs — linter, sanity, unit tests, plus documentation checks.
+
+---
+
+### User Story 3 - Documentation describes the branch model that exists (Priority: P3)
+
+The constitution, git-workflow guideline, release guide and AGENTS.md describe a single-branch model, so contributors and coding agents are not instructed to target a branch that is gone.
+
+**Why this priority**: Stale governance docs are actively misleading — the constitution is binding and currently mandates PRs target `develop`. Lower priority only because the mechanical change works without it; it must not be skipped.
+
+**Independent Test**: Grep the repository for `develop` and confirm every remaining hit is unrelated to the branch model.
+
+**Acceptance Scenarios**:
+
+1. **Given** the constitution is amended, **When** a reader checks the Development Workflow section, **Then** it names one long-lived branch and the amendment is versioned per the constitution's own governance rule.
+2. **Given** the docs are updated, **When** an agent reads AGENTS.md and follows its pointers, **Then** nothing instructs it to branch from or target `develop`.
+
+---
+
+### Edge Cases
+
+- **PR #405 "Backport Stable"** (`stable` → `develop`) becomes meaningless and must be closed rather than merged.
+- **PR #229** has been open a long time; it may conflict badly when rebased onto `stable` and may be better closed than retargeted. Decide per-PR rather than bulk-retargeting.
+- **Dependabot branch names embed the target** (`dependabot/pip/develop/...`); existing ones are abandoned and recreated rather than renamed.
+- **Branch protection currently protects `develop`** — its rules must be transferred to `stable`, not simply deleted, or the repo is briefly unprotected.
+- **`develop` is deleted while a contributor has it checked out locally** — they need `git remote prune` guidance; local copies are otherwise harmless.
+- **A release is in flight during the collapse** — the change must not run concurrently with a release attempt.
+- **The three commits on `stable` but not `develop`** need no action, but confirm they are genuinely present in `stable`'s history before deleting `develop`.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The repository's default branch MUST be `stable`.
+- **FR-002**: Every open pull request targeting `develop` MUST be retargeted to `stable` or explicitly closed, with a per-PR decision recorded.
+- **FR-003**: The `stable` → `develop` backport PR MUST be closed.
+- **FR-004**: Branch protection rules on `develop` MUST be transferred to `stable` before `develop` is deleted, leaving no window in which the surviving branch is unprotected.
+- **FR-005**: `develop` MUST be deleted only after FR-001 through FR-004 are complete and after confirming it holds no commits absent from `stable`.
+- **FR-006**: CI MUST run the full check set — linter, sanity, unit tests, and documentation checks — on every pull request to `stable`.
+- **FR-007**: The `develop`-specific PR trigger workflow MUST be removed and its checks preserved on the `stable` path.
+- **FR-008**: Dependabot MUST target `stable`.
+- **FR-009**: The upstream-tracking workflows MUST NOT offer `develop` as a target branch.
+- **FR-010**: The constitution MUST be amended to describe a single-branch model, with a version bump and sync-impact record per its own governance rule. Redefining the branch model is a breaking change to a documented workflow rule, so the bump is MAJOR.
+- **FR-011**: `dev/guidelines/git-workflow.md`, `dev/guides/releasing-the-collection.md`, `dev/README.md` and `AGENTS.md` MUST describe the single-branch model.
+- **FR-012**: No repository file may instruct a contributor or agent to branch from, or target, `develop`.
+
+### Key Entities
+
+- **`stable`**: the single long-lived branch; default, protected, and the base for all pull requests.
+- **`develop`**: removed. Currently the default branch, strictly behind `stable`.
+- **Branch protection ruleset**: currently applied to `develop`; transferred to `stable`.
+- **Constitution**: binding governance document encoding the branch model in four places; requires a versioned amendment.
+- **Open pull requests**: six against `develop`, each retargeted or closed by explicit decision.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Exactly one long-lived branch exists in the repository.
+- **SC-002**: 100% of open pull requests are resolved — retargeted to `stable` or closed with a reason — with none left pointing at a deleted branch.
+- **SC-003**: The surviving branch is protected at every point during the change; there is no interval with zero protected long-lived branches.
+- **SC-004**: Zero commits are lost — every commit reachable from `develop` before the change remains reachable from `stable` after it.
+- **SC-005**: A repository-wide search for `develop` returns no hit that refers to the branch model.
+- **SC-006**: The first dependency PR raised after the change targets `stable` without manual intervention.
+
+## Governance Gates Crossed
+
+Per this repository's `AGENTS.md` **Ask First** list:
+
+- [x] **Modifying CI workflows in `.github/workflows/`** — the develop PR trigger is removed and target-branch lists change.
+- [ ] Adding new dependencies — none.
+- [ ] Changing ruff configuration — not touched.
+- [ ] Modifying `plugins/module_utils/infrahub_utils.py` — not touched.
+- [ ] Changing `INFRAHUB_ARG_SPEC` — not touched.
+
+Beyond that list, this feature **amends the constitution**, whose Governance section requires that amendments update the document and the corresponding `dev/knowledge/` and `dev/guidelines/` files in sync. That synchronisation is FR-010 and FR-011, and it is the highest-order gate here — higher than the CI change, because the constitution is binding on every future PR.
+
+## Assumptions
+
+- No release is in flight while the collapse runs.
+- `develop` holds no unique commits — verified as `3 0` against `stable` at specification time, and to be re-verified immediately before deletion.
+- Contributors can be notified to prune local tracking branches; no automated cleanup of clones is attempted.
+- The checks currently running on PRs to `stable` are a superset of those on PRs to `develop`, so consolidating onto `stable` loses no coverage.
+- Single-branch delivery is the OpsMill default; the sibling repos already run this way, so this removes a divergence rather than inventing a model.
+
+## Out of Scope
+
+- The towncrier release process itself — specified as `002-towncrier-release-process`, which depends on this.
+- Changing the release cadence or what triggers a release, beyond removing the `develop` → `stable` merge as the trigger.
+- Renaming `stable` to `main` for consistency with infrahub-skills.
+- Applying the same collapse to any other repository.


### PR DESCRIPTION
## Summary

Specification only — **no implementation in this PR.** It proposes removing the `develop` branch and running a single long-lived `stable`, and exists so the plan can be reviewed before anything irreversible happens.

## Why

The two-branch model is already inverted in practice:

- `origin/stable...origin/develop` is **3 ahead, 0 behind** — `develop` contains nothing `stable` lacks, while `stable` carries three commits `develop` does not.
- Reconciliation runs *backwards*, through a standing "Backport Stable" PR (#405).

A branch that only ever receives backports is not an integration branch. Because nothing unique lives on `develop`, the collapse loses no work — there is no merge to perform, only references to repoint.

The sibling repositories already run one long-lived branch each (infrahub-mcp on `stable`, infrahub-skills on `main`), so this removes a divergence rather than inventing a model.

## What it covers

- Retargeting the six open PRs against `develop`, per-PR rather than in bulk — #229 is old enough that rebasing onto `stable` may be worse than closing it, and #405 becomes meaningless and should be closed rather than merged.
- **Transferring branch protection to `stable` before deleting `develop`**, so there is no window in which the surviving branch is unprotected.
- Repointing dependabot and the two upstream-tracking workflows, and removing the `develop` PR trigger.
- Amending the constitution, which encodes the branch model in four places and is binding on every future PR. Under its own governance rules that is a **MAJOR** version bump, and it requires the `dev/knowledge/` and `dev/guidelines/` files to move in sync.

## Relationship to #412

[#412](https://github.com/opsmill/infrahub-ansible/pull/412) implements the towncrier release process. It is **branch-model agnostic** and works under either model, so it does **not** depend on this landing. This spec simplifies that flow rather than enabling it.

## Two things to decide before implementing

**Branch protection on `stable` is currently empty** — 0 required approving reviews, 0 required status checks, `enforce_admins: false`. Whatever gets transferred from `develop` is what protects the single remaining branch, so this is the moment to decide what that should be rather than inheriting nothing.

**Per-PR calls on the six open PRs** — the spec deliberately does not prescribe bulk retargeting.

Not implemented, and I have not touched branch protection, the default branch, or any open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
This specification proposes replacing the current `develop`/`stable` model with one long-lived `stable` branch because `develop` has no unique commits and reconciliation already flows backward. It is planning only; this PR does not change branches, workflows, protections, open PRs, or documentation.

**Implementation scope**

- Make `stable` the default and protected branch, resolve the six open `develop` PRs individually, close backport PR #405, verify history, then delete `develop`.
- Remove the dependabot `target-branch: develop` pin (only after `stable` is default), close existing `develop` Dependabot PRs so they can be recreated, and retarget upstream-tracking workflows to `stable`.
- Preserve the `renovate/**` trigger and run lint, tests, documentation, and changelog checks on `stable` pull requests.
- Amend the constitution and update the eight repository documents that describe or instruct the current branch model.
- Exclude historical `.github/file-filters.yml` text and vendored `.agents/skills/**` references from the branch-model cleanup.
- Apply the collapse before `002-towncrier-release-process`, which depends on this change; do not run either change during an active release.

<sup>Written for commit b6ac74930aae547fc7b936f9ad5a26cda3bb92e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-ansible/pull/413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

